### PR TITLE
Attribute Finetuning

### DIFF
--- a/bin/pygac-fdr-mda-update
+++ b/bin/pygac-fdr-mda-update
@@ -18,7 +18,7 @@
 
 import argparse
 import logging
-from pygac_fdr.metadata import MetadataCollector, update_metadata
+from pygac_fdr.metadata import MetadataCollector, MetadataUpdater
 from pygac_fdr.utils import logging_on
 
 
@@ -34,4 +34,5 @@ if __name__ == '__main__':
 
     collector = MetadataCollector()
     mda = collector.read_sql(args.dbfile)
-    update_metadata(mda)
+    updater = MetadataUpdater()
+    updater.update(mda)

--- a/bin/pygac-fdr-run
+++ b/bin/pygac-fdr-run
@@ -60,7 +60,8 @@ if __name__ == '__main__':
         LOG.info('Processing file {}'.format(filename))
         try:
             scene = read_gac(filename, reader_kwargs=config['controls'].get('reader_kwargs'))
-            writer = NetcdfWriter(global_attrs=config.get('metadata'),
+            writer = NetcdfWriter(global_attrs=config.get('global_attrs'),
+                                  gac_header_attrs=config.get('gac_header_attrs'),
                                   fname_fmt=config['output'].get('fname_fmt'),
                                   encoding=config['netcdf'].get('encoding'),
                                   engine=config['netcdf'].get('engine'),

--- a/bin/pygac-fdr-run
+++ b/bin/pygac-fdr-run
@@ -18,6 +18,7 @@
 
 import argparse
 import logging
+import satpy
 from pygac_fdr.reader import read_gac
 from pygac_fdr.writer import NetcdfWriter
 from pygac_fdr.config import read_config
@@ -56,6 +57,7 @@ if __name__ == '__main__':
         config['controls']['debug'] = args.debug
 
     # Process files
+    satpy.CHUNK_SIZE = config['controls'].get('pytroll_chunk_size', 1024)
     for filename in args.filenames:
         LOG.info('Processing file {}'.format(filename))
         try:

--- a/etc/pygac-fdr.yaml
+++ b/etc/pygac-fdr.yaml
@@ -8,7 +8,7 @@ controls:
 output:
     output_dir: /data/avhrr_gac/output/
     fname_fmt: AVHRR-GAC_FDR_{processing_level}_{platform}_{start_time}_{end_time}_{processing_mode}_{disposition_mode}_{creation_time}_{version_int:04d}.nc
-metadata:
+global_attrs:
     id: DOI:10.5676/EUM/AVHRR_GAC_L1C_FDR/V0100
     title: AVHRR GAC L1C FDR
     product_version: 1.0.0
@@ -44,6 +44,10 @@ metadata:
     standard_name_vocabulary: CF Standard Name Table v73
     licence: EUMETSAT data policy https://www.eumetsat.int/website/home/AboutUs/WhoWeAre/LegalFramework/DataPolicy/index.html
     history:
+gac_header_attrs:
+    title: Raw GAC Header
+    references: >-
+        NOAA POD & KLM user guides, https://www1.ncdc.noaa.gov/pub/data/satellite/publications/podguides/
 netcdf:
     engine: netcdf4
     encoding:

--- a/etc/pygac-fdr.yaml
+++ b/etc/pygac-fdr.yaml
@@ -18,7 +18,7 @@ global_attrs:
     creator_url: https://www.eumetsat.int/
     creator_email: ops@eumetsat.int
     naming_authority: int.eumetsat
-    comment: Developed in cooperation with EUM CM SAF and the PyTroll community.
+    comment: Developed in cooperation with EUMETSAT CM SAF and the PyTroll community.
     summary: >-
         Fundamental Data Record (FDR) of measurements from the Advanced Very High Resolution Radiometer (AVHRR) at
         full Global Area Coverage (GAC) resolution. AVHRR GAC measurements have been calibrated to Level 1C using the

--- a/etc/pygac-fdr.yaml
+++ b/etc/pygac-fdr.yaml
@@ -5,6 +5,7 @@ controls:
         tle_name: TLE_%(satname)s.txt
         tle_thresh: 1000
         calibration_file: /data/avhrr_gac/calibration.json
+    pytroll_chunk_size: 1024
 output:
     output_dir: /data/avhrr_gac/output/
     fname_fmt: AVHRR-GAC_FDR_{processing_level}_{platform}_{start_time}_{end_time}_{processing_mode}_{disposition_mode}_{creation_time}_{version_int:04d}.nc

--- a/etc/pygac-fdr.yaml
+++ b/etc/pygac-fdr.yaml
@@ -12,7 +12,10 @@ global_attrs:
     id: DOI:10.5676/EUM/AVHRR_GAC_L1C_FDR/V0100
     title: AVHRR GAC L1C FDR
     product_version: 1.0.0
-    institution: EUMETSAT, ops@eumetsat.int
+    institution: EUMETSAT
+    creator_name: EUMETSAT
+    creator_url: https://www.eumetsat.int/
+    creator_email: ops@eumetsat.int
     naming_authority: int.eumetsat
     comment: Developed in cooperation with EUM CM SAF and the PyTroll community.
     summary: >-

--- a/pygac_fdr/writer.py
+++ b/pygac_fdr/writer.py
@@ -337,6 +337,12 @@ class NetcdfWriter:
                 continue
             del scene[old_name]
 
+    def _set_custom_attrs(self, scene):
+        """Set custom dataset attributes."""
+        scene['qual_flags'].attrs['comment'] = 'Seven binary quality flags are provided per ' \
+                                               'scanline. See the num_flags coordinate for their ' \
+                                               'meanings.'
+
     def _get_encoding(self, scene):
         """Get netCDF encoding for the datasets in the scene."""
         # Remove entries from the encoding dictionary if the corresponding dataset is not available.
@@ -375,6 +381,7 @@ class NetcdfWriter:
         gac_header = scene['4'].attrs['gac_header'].copy()
         global_attrs = self._get_global_attrs(scene)
         self._cleanup_attrs(scene)
+        self._set_custom_attrs(scene)
         self._rename_datasets(scene)
         encoding = self._get_encoding(scene)
         LOG.info('Writing calibrated scene to {}'.format(filename))

--- a/pygac_fdr/writer.py
+++ b/pygac_fdr/writer.py
@@ -207,12 +207,14 @@ class NetcdfWriter:
     time_fmt = '%Y%m%dT%H%M%SZ'
     def_engine = 'netcdf4'
 
-    def __init__(self, global_attrs=None, encoding=None, engine=None, fname_fmt=None, debug=None):
+    def __init__(self, global_attrs=None, gac_header_attrs=None, encoding=None, engine=None,
+                 fname_fmt=None, debug=None):
         """
         Args:
             debug: If True, use constant creation time in output filenames.
         """
         self.global_attrs = global_attrs or {}
+        self.gac_header_attrs = gac_header_attrs or {}
         self.engine = engine or self.def_engine
         self.fname_fmt = fname_fmt or self.def_fname_fmt
         self.debug = bool(debug)
@@ -392,7 +394,7 @@ class NetcdfWriter:
         """Append raw GAC header to the given netCDF file."""
         LOG.info('Appending GAC header')
         data_vars = dict([(name, header[name]) for name in header.dtype.names])
-        header = xr.Dataset(data_vars, attrs={'title': 'Raw GAC header'})
+        header = xr.Dataset(data_vars, attrs=self.gac_header_attrs)
         header.to_netcdf(filename, mode='a', group='gac_header')
 
     def write(self, scene, output_dir=None):

--- a/pygac_fdr/writer.py
+++ b/pygac_fdr/writer.py
@@ -22,6 +22,7 @@ from datetime import datetime
 from distutils.version import StrictVersion
 import logging
 import netCDF4
+import numpy as np
 import os
 import satpy
 from string import Formatter
@@ -352,7 +353,16 @@ class NetcdfWriter:
         scn_keys = set([key.name for key in scene.keys()])
         scn_keys = scn_keys.union(
             set([coord for key in scene.keys() for coord in scene[key].coords]))
-        return dict([(key, self.encoding[key]) for key in enc_keys.intersection(scn_keys)])
+        encoding = dict([(key, self.encoding[key]) for key in enc_keys.intersection(scn_keys)])
+
+        # Make sure scale_factor and add_offset are both double
+        for enc in encoding.values():
+            if 'scale_factor' in enc:
+                enc['scale_factor'] = np.float64(enc['scale_factor'])
+            if 'add_offset' in enc:
+                enc['add_offset'] = np.float64(enc['add_offset'])
+
+        return encoding
 
     def _fix_global_attrs(self, filename, global_attrs):
         LOG.info('Fixing global attributes')

--- a/pygac_fdr/writer.py
+++ b/pygac_fdr/writer.py
@@ -48,7 +48,8 @@ FILL_VALUE_INT16 = -32767
 FILL_VALUE_INT32 = -2147483648
 DEFAULT_ENCODING = {
     'acq_time': {'units': 'seconds since 1970-01-01 00:00:00',
-                 'calendar': 'standard'},
+                 'calendar': 'standard',
+                 '_FillValue': None},
     'reflectance_channel_1': {'dtype': 'int16',
                               'scale_factor': 0.01,
                               'add_offset': 0,


### PR DESCRIPTION
Closes #11 

This PR will change the config file format (`metadata` -> `global_attrs`, new section `gac_header_attrs`).

Answers
-------------
Possible Improvements:

1. Yes they could be expressed as a bit map, but in my experience decoding bitmaps is challenging for some users. But I added a comment pointing to the flag meanings.
2. Removed fill value
3. Fixed

Trivial attribute tweaks:
1. Added `standard_name` and `axis` attributes to `acq_time`. 
2. Lon/lat are 2D. Instead added 1D `y` and `x` coordinates for pixel/line number, including `axis` attributes.
3. Moved contact to `creator_email`. TODO: Is our interpretation of `time_coverage_start/end` incorrect?
4. Ignored :slightly_smiling_face: 
5. Fixed, see https://github.com/pytroll/satpy/pull/1254 
6. Added reference to POD/KLM user guides