### PR TITLE
Code formatting and pre-commit hooks

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,16 @@
+# https://pre-commit.com/
+repos:
+  # isort should run before black as black sometimes tweaks the isort output
+  - repo: https://github.com/PyCQA/isort
+    rev: 5.5.4
+    hooks:
+      - id: isort
+  # https://github.com/python/black#version-control-integration
+  - repo: https://github.com/psf/black
+    rev: 20.8b1
+    hooks:
+      - id: black
+  - repo: https://gitlab.com/pycqa/flake8
+    rev: 3.8.3
+    hooks:
+      - id: flake8

--- a/bin/pygac-fdr-dump
+++ b/bin/pygac-fdr-dump
@@ -18,10 +18,10 @@
 """Print contents of metadata database."""
 
 import argparse
+
 import pandas as pd
 
 from pygac_fdr.metadata import MetadataCollector
-
 
 if __name__ == '__main__':
     parser = argparse.ArgumentParser(description=__doc__)

--- a/bin/pygac-fdr-dump
+++ b/bin/pygac-fdr-dump
@@ -23,19 +23,18 @@ import pandas as pd
 
 from pygac_fdr.metadata import MetadataCollector
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     parser = argparse.ArgumentParser(description=__doc__)
-    parser.add_argument('dbfile', help='Metadata database')
-    parser.add_argument('-n', help='Maximum number of rows to be printed',
-                        type=int)
+    parser.add_argument("dbfile", help="Metadata database")
+    parser.add_argument("-n", help="Maximum number of rows to be printed", type=int)
     args = parser.parse_args()
 
     collector = MetadataCollector()
     mda = collector.read_sql(args.dbfile)
 
-    pd.set_option('display.max_rows', args.n)
-    pd.set_option('display.max_columns', None)
-    pd.set_option('display.width', None)
-    pd.set_option('display.max_colwidth', 22)
+    pd.set_option("display.max_rows", args.n)
+    pd.set_option("display.max_columns", None)
+    pd.set_option("display.width", None)
+    pd.set_option("display.max_colwidth", 22)
 
     print(mda)

--- a/bin/pygac-fdr-mda-collect
+++ b/bin/pygac-fdr-mda-collect
@@ -19,9 +19,9 @@
 
 import argparse
 import logging
-from pygac_fdr.metadata import MetadataCollector
-from pygac_fdr.utils import logging_on, LOGGER_NAME
 
+from pygac_fdr.metadata import MetadataCollector
+from pygac_fdr.utils import LOGGER_NAME, logging_on
 
 LOG = logging.getLogger(LOGGER_NAME)
 

--- a/bin/pygac-fdr-mda-collect
+++ b/bin/pygac-fdr-mda-collect
@@ -30,15 +30,21 @@ tooltip: %(prog)s --dbfile example.db @example_filenames.txt;
 for reading a long list of filenames from an arguments file.
 """
 
-if __name__ == '__main__':
-    parser = argparse.ArgumentParser(description=__doc__,
-                                     fromfile_prefix_chars='@',
-                                     epilog=tooltip)
-    parser.add_argument('--dbfile', required=True, type=str, help='Metadata database to be written')
-    parser.add_argument('--if-exists', choices=('append', 'fail', 'replace'), default='fail',
-                        help='What to do if database table already exists')
-    parser.add_argument('filenames', nargs='+', help='Level 1c files to be analyzed')
-    parser.add_argument('--verbose', action='store_true', help='Increase verbosity')
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser(
+        description=__doc__, fromfile_prefix_chars="@", epilog=tooltip
+    )
+    parser.add_argument(
+        "--dbfile", required=True, type=str, help="Metadata database to be written"
+    )
+    parser.add_argument(
+        "--if-exists",
+        choices=("append", "fail", "replace"),
+        default="fail",
+        help="What to do if database table already exists",
+    )
+    parser.add_argument("filenames", nargs="+", help="Level 1c files to be analyzed")
+    parser.add_argument("--verbose", action="store_true", help="Increase verbosity")
     args = parser.parse_args()
     logging_on(logging.DEBUG if args.verbose else logging.INFO)
 

--- a/bin/pygac-fdr-mda-update
+++ b/bin/pygac-fdr-mda-update
@@ -18,9 +18,9 @@
 
 import argparse
 import logging
+
 from pygac_fdr.metadata import MetadataCollector, MetadataUpdater
 from pygac_fdr.utils import logging_on
-
 
 if __name__ == '__main__':
     parser = argparse.ArgumentParser(description='Update metadata in level 1c files')

--- a/bin/pygac-fdr-mda-update
+++ b/bin/pygac-fdr-mda-update
@@ -22,13 +22,15 @@ import logging
 from pygac_fdr.metadata import MetadataCollector, MetadataUpdater
 from pygac_fdr.utils import logging_on
 
-if __name__ == '__main__':
-    parser = argparse.ArgumentParser(description='Update metadata in level 1c files')
-    parser.add_argument('--dbfile',
-                        required=True,
-                        type=str,
-                        help='Metadata database created with pygac-fdr-mda-collect')
-    parser.add_argument('--verbose', action='store_true', help='Increase verbosity')
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser(description="Update metadata in level 1c files")
+    parser.add_argument(
+        "--dbfile",
+        required=True,
+        type=str,
+        help="Metadata database created with pygac-fdr-mda-collect",
+    )
+    parser.add_argument("--verbose", action="store_true", help="Increase verbosity")
     args = parser.parse_args()
     logging_on(logging.DEBUG if args.verbose else logging.INFO)
 

--- a/bin/pygac-fdr-run
+++ b/bin/pygac-fdr-run
@@ -29,26 +29,36 @@ from pygac_fdr.writer import NetcdfWriter
 LOG = logging.getLogger(LOGGER_NAME)
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     # Parse command line arguments
-    parser = argparse.ArgumentParser(description='Read & calibrate AVHRR GAC data and write '
-                                                 'results to netCDF')
-    parser.add_argument('--cfg',
-                        required=True,
-                        type=str,
-                        help='Path to pygac-fdr configuration file.')
-    parser.add_argument('--output-dir',
-                        help='Output directory. Overrides entry in the configuration file.')
-    parser.add_argument('--tle-dir',
-                        help='Directory containing TLE files. Overrides entry in the configuration'
-                             ' file.')
-    parser.add_argument('--debug',
-                        action='store_true',
-                        help='Enable debug mode, i.e. exit on first error. Otherwise continue with '
-                             'next file. Overrides entry in the configuration file.')
-    parser.add_argument('--verbose', action='store_true', help='Increase verbosity')
-    parser.add_argument('--log-all', action='store_true', help='Enable logging for all modules')
-    parser.add_argument('filenames', nargs='+', help='AVHRR GAC level 1b files to be processed')
+    parser = argparse.ArgumentParser(
+        description="Read & calibrate AVHRR GAC data and write " "results to netCDF"
+    )
+    parser.add_argument(
+        "--cfg", required=True, type=str, help="Path to pygac-fdr configuration file."
+    )
+    parser.add_argument(
+        "--output-dir",
+        help="Output directory. Overrides entry in the configuration file.",
+    )
+    parser.add_argument(
+        "--tle-dir",
+        help="Directory containing TLE files. Overrides entry in the configuration"
+        " file.",
+    )
+    parser.add_argument(
+        "--debug",
+        action="store_true",
+        help="Enable debug mode, i.e. exit on first error. Otherwise continue with "
+        "next file. Overrides entry in the configuration file.",
+    )
+    parser.add_argument("--verbose", action="store_true", help="Increase verbosity")
+    parser.add_argument(
+        "--log-all", action="store_true", help="Enable logging for all modules"
+    )
+    parser.add_argument(
+        "filenames", nargs="+", help="AVHRR GAC level 1b files to be processed"
+    )
     args = parser.parse_args()
     logging_on(logging.DEBUG if args.verbose else logging.INFO, for_all=args.log_all)
 
@@ -56,26 +66,30 @@ if __name__ == '__main__':
     # line.
     config = read_config(args.cfg)
     if args.output_dir:
-        config['output']['output_dir'] = args.output_dir
+        config["output"]["output_dir"] = args.output_dir
     if args.tle_dir:
-        config['controls']['reader_kwargs']['tle_dir'] = args.tle_dir
+        config["controls"]["reader_kwargs"]["tle_dir"] = args.tle_dir
     if args.debug:
-        config['controls']['debug'] = args.debug
+        config["controls"]["debug"] = args.debug
 
     # Process files
-    satpy.CHUNK_SIZE = config['controls'].get('pytroll_chunk_size', 1024)
+    satpy.CHUNK_SIZE = config["controls"].get("pytroll_chunk_size", 1024)
     for filename in args.filenames:
-        LOG.info('Processing file {}'.format(filename))
+        LOG.info("Processing file {}".format(filename))
         try:
-            scene = read_gac(filename, reader_kwargs=config['controls'].get('reader_kwargs'))
-            writer = NetcdfWriter(global_attrs=config.get('global_attrs'),
-                                  gac_header_attrs=config.get('gac_header_attrs'),
-                                  fname_fmt=config['output'].get('fname_fmt'),
-                                  encoding=config['netcdf'].get('encoding'),
-                                  engine=config['netcdf'].get('engine'),
-                                  debug=config['controls'].get('debug'))
-            writer.write(output_dir=config['output'].get('output_dir'), scene=scene)
+            scene = read_gac(
+                filename, reader_kwargs=config["controls"].get("reader_kwargs")
+            )
+            writer = NetcdfWriter(
+                global_attrs=config.get("global_attrs"),
+                gac_header_attrs=config.get("gac_header_attrs"),
+                fname_fmt=config["output"].get("fname_fmt"),
+                encoding=config["netcdf"].get("encoding"),
+                engine=config["netcdf"].get("engine"),
+                debug=config["controls"].get("debug"),
+            )
+            writer.write(output_dir=config["output"].get("output_dir"), scene=scene)
         except Exception as err:
-            if config['controls']['debug']:
+            if config["controls"]["debug"]:
                 raise
-            LOG.error('Error processing file {}: {}'.format(filename, err))
+            LOG.error("Error processing file {}: {}".format(filename, err))

--- a/bin/pygac-fdr-run
+++ b/bin/pygac-fdr-run
@@ -18,12 +18,13 @@
 
 import argparse
 import logging
-import satpy
-from pygac_fdr.reader import read_gac
-from pygac_fdr.writer import NetcdfWriter
-from pygac_fdr.config import read_config
-from pygac_fdr.utils import logging_on, LOGGER_NAME
 
+import satpy
+
+from pygac_fdr.config import read_config
+from pygac_fdr.reader import read_gac
+from pygac_fdr.utils import LOGGER_NAME, logging_on
+from pygac_fdr.writer import NetcdfWriter
 
 LOG = logging.getLogger(LOGGER_NAME)
 

--- a/etc/pygac-fdr.yaml
+++ b/etc/pygac-fdr.yaml
@@ -26,14 +26,14 @@ global_attrs:
         reflectance or brightness temperature as well as inter-sensor calibration. The data are accompanied by
         additional metadata (such as orbit overlap and equator crossing time) as well as basic quality indicators.
     references: >-
-        Devasthale, A., M. Raspaud, C. Schlundt, T. Hanschmann, S. Finkensieper, A. Dybbroe, S. Hörnquist,
-        N. Håkansson, M. Stengel and K-G. Karlsson. "PyGAC: An open-source, community-driven Python interface to
+        Devasthale, A., M. Raspaud, C. Schlundt, T. Hanschmann, S. Finkensieper, A. Dybbroe, S. Hornquist,
+        N. Hakansson, M. Stengel and K-G. Karlsson. "PyGAC: An open-source, community-driven Python interface to
         preprocess nearly 40-year AVHRR Global Area Coverage (GAC) data record",
         GSICS Quarterly Newsletter, Vol. 11, No. 2 (Sept. 2017): 3-5. DOI: 10.7289/V5R78CFR.
 
         Heidinger, A. K., W. C. Straka, C. C. Molling, J. T. Sullivan, and X. Q. Wu, Deriving an inter-sensor
         consistent calibration for the AVHRR solar reflectance data record, International Journal of Remote Sensing,
-        vol. 31, no. 24, pp. 6493–6517, 2010.
+        vol. 31, no. 24, pp. 6493-6517, 2010.
     keywords: >-
         ATMOSPHERE > ATMOSPHERIC RADIATION > REFLECTANCE,
         ATMOSPHERE > ATMOSPHERIC RADIATION > OUTGOING LONGWAVE RADIATION,

--- a/pygac_fdr/__init__.py
+++ b/pygac_fdr/__init__.py
@@ -16,8 +16,7 @@
 # You should have received a copy of the GNU General Public License along with
 # pygac-fdr. If not, see <http://www.gnu.org/licenses/>.
 
-from pkg_resources import get_distribution, DistributionNotFound
-
+from pkg_resources import DistributionNotFound, get_distribution
 
 try:
     __version__ = get_distribution(__name__).version

--- a/pygac_fdr/config.py
+++ b/pygac_fdr/config.py
@@ -26,7 +26,7 @@ def read_config(filename):
         config = yaml.safe_load(fh)
 
     # Add empty dictionaries for required sections
-    for required in ['controls', 'output', 'netcdf']:
+    for required in ["controls", "output", "netcdf"]:
         if required not in config or config[required] is None:
             config[required] = {}
 

--- a/pygac_fdr/metadata.py
+++ b/pygac_fdr/metadata.py
@@ -33,22 +33,22 @@ LOG = logging.getLogger(__package__)
 
 
 TIME_COVERAGE = {
-    'METOP-A': (datetime(2007, 6, 28, 23, 14), None),
-    'METOP-B': (datetime(2013, 1, 1, 1, 1), None),
-    'NOAA-6': (datetime(1980, 1, 1, 0, 0), datetime(1982, 8, 3, 0, 39)),
-    'NOAA-7': (datetime(1981, 8, 24, 0, 13), datetime(1985, 2, 1, 22, 21)),
-    'NOAA-8': (datetime(1983, 5, 4, 19, 9), datetime(1985, 10, 14, 3, 26)),
-    'NOAA-9': (datetime(1985, 2, 25, 0, 13), datetime(1988, 11, 7, 21, 18)),
-    'NOAA-10': (datetime(1986, 11, 17, 1, 22), datetime(1991, 9, 16, 21, 19)),
-    'NOAA-11': (datetime(1988, 11, 8, 0, 16), datetime(1994, 10, 16, 23, 27)),
-    'NOAA-12': (datetime(1991, 9, 16, 0, 17), datetime(1998, 12, 14, 20, 43)),
-    'NOAA-14': (datetime(1995, 1, 20, 0, 37), datetime(2002, 10, 7, 22, 47)),
-    'NOAA-15': (datetime(1998, 10, 26, 0, 54), None),
-    'NOAA-16': (datetime(2001, 1, 1, 0, 0), datetime(2011, 12, 31, 23, 40)),
-    'NOAA-17': (datetime(2002, 6, 25, 5, 41), datetime(2011, 12, 31, 19, 11)),
-    'NOAA-18': (datetime(2005, 5, 20, 18, 17), None),
-    'NOAA-19': (datetime(2009, 2, 6, 18, 32), None),
-    'TIROS-N': (datetime(1978, 11, 5, 9, 8), datetime(1980, 1, 30, 17, 3))
+    "METOP-A": (datetime(2007, 6, 28, 23, 14), None),
+    "METOP-B": (datetime(2013, 1, 1, 1, 1), None),
+    "NOAA-6": (datetime(1980, 1, 1, 0, 0), datetime(1982, 8, 3, 0, 39)),
+    "NOAA-7": (datetime(1981, 8, 24, 0, 13), datetime(1985, 2, 1, 22, 21)),
+    "NOAA-8": (datetime(1983, 5, 4, 19, 9), datetime(1985, 10, 14, 3, 26)),
+    "NOAA-9": (datetime(1985, 2, 25, 0, 13), datetime(1988, 11, 7, 21, 18)),
+    "NOAA-10": (datetime(1986, 11, 17, 1, 22), datetime(1991, 9, 16, 21, 19)),
+    "NOAA-11": (datetime(1988, 11, 8, 0, 16), datetime(1994, 10, 16, 23, 27)),
+    "NOAA-12": (datetime(1991, 9, 16, 0, 17), datetime(1998, 12, 14, 20, 43)),
+    "NOAA-14": (datetime(1995, 1, 20, 0, 37), datetime(2002, 10, 7, 22, 47)),
+    "NOAA-15": (datetime(1998, 10, 26, 0, 54), None),
+    "NOAA-16": (datetime(2001, 1, 1, 0, 0), datetime(2011, 12, 31, 23, 40)),
+    "NOAA-17": (datetime(2002, 6, 25, 5, 41), datetime(2011, 12, 31, 19, 11)),
+    "NOAA-18": (datetime(2005, 5, 20, 18, 17), None),
+    "NOAA-19": (datetime(2009, 2, 6, 18, 32), None),
+    "TIROS-N": (datetime(1978, 11, 5, 9, 8), datetime(1980, 1, 30, 17, 3)),
 }  # Estimated based on NOAA L1B archive
 
 
@@ -62,43 +62,58 @@ class QualityFlags(IntEnum):
 
 
 FILL_VALUE_INT = -9999
-FILL_VALUE_FLOAT = -9999.
+FILL_VALUE_FLOAT = -9999.0
 
 ADDITIONAL_METADATA = [
-    {'name': 'overlap_free_start',
-     'long_name': 'First scanline (0-based) of the overlap-free part of this file. Scanlines '
-                  'before that also appear in the preceding file.',
-     'dtype': np.int16,
-     'fill_value': FILL_VALUE_INT},
-    {'name': 'overlap_free_end',
-     'long_name': 'Last scanline (0-based) of the overlap-free part of this file. Scanlines '
-                  'hereafter also appear in the subsequent file.',
-     'dtype': np.int16,
-     'fill_value': FILL_VALUE_INT},
-    {'name': 'midnight_line',
-     'long_name': 'Scanline (0-based) where UTC timestamp crosses the dateline',
-     'dtype': np.int16,
-     'fill_value': FILL_VALUE_INT},
-    {'name': 'equator_crossing_longitude',
-     'long_name': 'Longitude where ascending node crosses the equator (can happen twice per file)',
-     'units': 'degrees_east',
-     'dtype': np.float64,
-     'fill_value': FILL_VALUE_FLOAT},
-    {'name': 'equator_crossing_time',
-     'long_name': 'UTC time when ascending node crosses the equator (can happen twice per file)',
-     'units': 'seconds since 1970-01-01 00:00:00',
-     'calendar': 'standard',
-     'dtype': np.float64,
-     'fill_value': FILL_VALUE_FLOAT},
-    {'name': 'global_quality_flag',
-     'long_name': 'Global quality flag',
-     'comment': 'If this flag is everything else than "ok", it is recommended not '
-                'to use the file.',
-     'flag_values': np.array([flag.value for flag in QualityFlags.__members__.values()],
-                             dtype=np.uint8),
-     'flag_meanings': ' '.join([name.lower() for name in QualityFlags.__members__.keys()]),
-     'dtype': np.uint8,
-     'fill_value': None}
+    {
+        "name": "overlap_free_start",
+        "long_name": "First scanline (0-based) of the overlap-free part of this file. Scanlines "
+        "before that also appear in the preceding file.",
+        "dtype": np.int16,
+        "fill_value": FILL_VALUE_INT,
+    },
+    {
+        "name": "overlap_free_end",
+        "long_name": "Last scanline (0-based) of the overlap-free part of this file. Scanlines "
+        "hereafter also appear in the subsequent file.",
+        "dtype": np.int16,
+        "fill_value": FILL_VALUE_INT,
+    },
+    {
+        "name": "midnight_line",
+        "long_name": "Scanline (0-based) where UTC timestamp crosses the dateline",
+        "dtype": np.int16,
+        "fill_value": FILL_VALUE_INT,
+    },
+    {
+        "name": "equator_crossing_longitude",
+        "long_name": "Longitude where ascending node crosses the equator (can happen twice per file)",
+        "units": "degrees_east",
+        "dtype": np.float64,
+        "fill_value": FILL_VALUE_FLOAT,
+    },
+    {
+        "name": "equator_crossing_time",
+        "long_name": "UTC time when ascending node crosses the equator (can happen twice per file)",
+        "units": "seconds since 1970-01-01 00:00:00",
+        "calendar": "standard",
+        "dtype": np.float64,
+        "fill_value": FILL_VALUE_FLOAT,
+    },
+    {
+        "name": "global_quality_flag",
+        "long_name": "Global quality flag",
+        "comment": 'If this flag is everything else than "ok", it is recommended not '
+        "to use the file.",
+        "flag_values": np.array(
+            [flag.value for flag in QualityFlags.__members__.values()], dtype=np.uint8
+        ),
+        "flag_meanings": " ".join(
+            [name.lower() for name in QualityFlags.__members__.keys()]
+        ),
+        "dtype": np.uint8,
+        "fill_value": None,
+    },
 ]
 
 
@@ -108,6 +123,7 @@ class MetadataCollector:
     Additional metadata include global quality flags as well equator crossing time and
     overlap information.
     """
+
     def __init__(self, min_num_lines=50, min_duration=5):
         """
         Args:
@@ -117,66 +133,70 @@ class MetadataCollector:
                           it will flagged as too short.
         """
         self.min_num_lines = min_num_lines
-        self.min_duration = np.timedelta64(min_duration, 'm')
+        self.min_duration = np.timedelta64(min_duration, "m")
 
     def get_metadata(self, filenames):
         """Collect and complement metadata from the given level 1c files."""
-        LOG.info('Collecting metadata')
+        LOG.info("Collecting metadata")
         df = pd.DataFrame(self._collect_metadata(filenames))
-        df.sort_values(by=['start_time', 'end_time'], inplace=True)
+        df.sort_values(by=["start_time", "end_time"], inplace=True)
 
         # Set quality flags
-        LOG.info('Computing quality flags')
-        df = df.groupby('platform').apply(lambda x: self._set_global_qual_flags(x, x.name))
-        df = df.drop(['platform'], axis=1)
+        LOG.info("Computing quality flags")
+        df = df.groupby("platform").apply(
+            lambda x: self._set_global_qual_flags(x, x.name)
+        )
+        df = df.drop(["platform"], axis=1)
 
         # Calculate overlap
-        LOG.info('Computing overlap')
-        df = df.groupby('platform').apply(lambda x: self._calc_overlap(x))
+        LOG.info("Computing overlap")
+        df = df.groupby("platform").apply(lambda x: self._calc_overlap(x))
 
         return df
 
     def save_sql(self, mda, dbfile, if_exists):
         """Save metadata to sqlite database."""
         con = sqlite3.connect(dbfile)
-        mda.to_sql(name='metadata', con=con, if_exists=if_exists)
+        mda.to_sql(name="metadata", con=con, if_exists=if_exists)
         con.commit()
         con.close()
 
     def read_sql(self, dbfile):
         """Read metadata from sqlite database."""
         with sqlite3.connect(dbfile) as con:
-            mda = pd.read_sql('select * from metadata', con)
-        mda = mda.set_index(['platform', 'level_1'])
+            mda = pd.read_sql("select * from metadata", con)
+        mda = mda.set_index(["platform", "level_1"])
         mda.fillna(value=np.nan, inplace=True)
         for col in mda.columns:
-            if 'time' in col:
-                mda[col] = mda[col].astype('datetime64[ns]')
+            if "time" in col:
+                mda[col] = mda[col].astype("datetime64[ns]")
         return mda
 
     def _collect_metadata(self, filenames):
         """Collect metadata from the given level 1c files."""
         records = []
         for filename in filenames:
-            LOG.debug('Collecting metadata from {}'.format(filename))
+            LOG.debug("Collecting metadata from {}".format(filename))
             with xr.open_dataset(filename) as ds:
-                midnight_line = np.float64(self._get_midnight_line(ds['acq_time']))
+                midnight_line = np.float64(self._get_midnight_line(ds["acq_time"]))
                 eq_cross_lons, eq_cross_times = self._get_equator_crossings(ds)
-                rec = {'platform':  ds.attrs['platform'].split('>')[-1].strip(),
-                       'start_time': ds['acq_time'].values[0],
-                       'end_time': ds['acq_time'].values[-1],
-                       'along_track': ds.dims['y'],
-                       'filename': filename,
-                       'orbit_number_start': ds.attrs['orbit_number_start'],
-                       'orbit_number_end': ds.attrs['orbit_number_end'],
-                       'equator_crossing_longitude_1': eq_cross_lons[0],
-                       'equator_crossing_time_1': eq_cross_times[0],
-                       'equator_crossing_longitude_2': eq_cross_lons[1],
-                       'equator_crossing_time_2': eq_cross_times[1],
-                       'midnight_line': midnight_line,
-                       'overlap_free_start': np.nan,
-                       'overlap_free_end': np.nan,
-                       'global_quality_flag': QualityFlags.OK}
+                rec = {
+                    "platform": ds.attrs["platform"].split(">")[-1].strip(),
+                    "start_time": ds["acq_time"].values[0],
+                    "end_time": ds["acq_time"].values[-1],
+                    "along_track": ds.dims["y"],
+                    "filename": filename,
+                    "orbit_number_start": ds.attrs["orbit_number_start"],
+                    "orbit_number_end": ds.attrs["orbit_number_end"],
+                    "equator_crossing_longitude_1": eq_cross_lons[0],
+                    "equator_crossing_time_1": eq_cross_times[0],
+                    "equator_crossing_longitude_2": eq_cross_lons[1],
+                    "equator_crossing_time_2": eq_cross_times[1],
+                    "midnight_line": midnight_line,
+                    "overlap_free_start": np.nan,
+                    "overlap_free_end": np.nan,
+                    "global_quality_flag": QualityFlags.OK,
+                }
                 records.append(rec)
         return records
 
@@ -187,13 +207,15 @@ class MetadataCollector:
             int: The midnight scanline if it exists.
                  None, else.
         """
-        d0 = np.datetime64('1970-01-01', 'D')
-        days = (acq_time.astype('datetime64[D]') - d0) / np.timedelta64(1, 'D')
+        d0 = np.datetime64("1970-01-01", "D")
+        days = (acq_time.astype("datetime64[D]") - d0) / np.timedelta64(1, "D")
         incr = np.where(np.diff(days) == 1)[0]
         if len(incr) >= 1:
             if len(incr) > 1:
-                LOG.warning('UTC date increases more than once. Choosing the first '
-                            'occurence as midnight scanline.')
+                LOG.warning(
+                    "UTC date increases more than once. Choosing the first "
+                    "occurence as midnight scanline."
+                )
             return incr[0]
         return np.nan
 
@@ -203,7 +225,7 @@ class MetadataCollector:
         Returns:
             Longitudes and UTC times of first and second equator crossing, if any, NaN else.
         """
-        lat = ds['latitude'].load()  # load dataset to prevent netCDF4 indexing error
+        lat = ds["latitude"].load()  # load dataset to prevent netCDF4 indexing error
 
         # Use coordinates in the middle of the swath
         mid_swath = lat.shape[1] // 2
@@ -215,9 +237,11 @@ class MetadataCollector:
 
         num_cross = min(2, len(lat_eq))  # Two crossings max
         eq_cross_lons = np.full(2, np.nan)
-        eq_cross_times = np.full(2, np.datetime64('NaT'), dtype=lat_eq['acq_time'].dtype)
-        eq_cross_lons[0:num_cross] = lat_eq['longitude'].values[0:num_cross]
-        eq_cross_times[0:num_cross] = lat_eq['acq_time'].values[0:num_cross]
+        eq_cross_times = np.full(
+            2, np.datetime64("NaT"), dtype=lat_eq["acq_time"].dtype
+        )
+        eq_cross_lons[0:num_cross] = lat_eq["longitude"].values[0:num_cross]
+        eq_cross_times[0:num_cross] = lat_eq["acq_time"].values[0:num_cross]
         return eq_cross_lons, eq_cross_times
 
     def _set_redundant_flag(self, df, window=20):
@@ -236,39 +260,44 @@ class MetadataCollector:
             |--------|  current file
               |---------|  subsequent file
         """
+
         def is_redundant(end_times):
-            start_times = end_times.index.get_level_values('start_time').to_numpy()
+            start_times = end_times.index.get_level_values("start_time").to_numpy()
             end_times = end_times.to_numpy()
             this_start_time = start_times[-1]
             this_end_time = end_times[-1]
-            redundant = (this_start_time >= start_times[:-1]) & (this_end_time <= end_times[:-1])
+            redundant = (this_start_time >= start_times[:-1]) & (
+                this_end_time <= end_times[:-1]
+            )
             return redundant.any()
 
         # Only take into account files that passed the QC check so far (e.g. we don't want
         # files flagged as TOO_LONG to overlap many subsequent files)
-        df_ok = df[df['global_quality_flag'] == QualityFlags.OK].copy()
+        df_ok = df[df["global_quality_flag"] == QualityFlags.OK].copy()
 
         # Sort by ascending start time and descending end time. This is required to catch
         # redundant files with identical start times but different end times.
-        df_ok = df_ok.sort_values(by=['start_time', 'end_time'], ascending=[True, False])
+        df_ok = df_ok.sort_values(
+            by=["start_time", "end_time"], ascending=[True, False]
+        )
 
         # DataFrame.rolling is an elegant solution, but it has two drawbacks:
         # a) It only supports numerical data types. Workaround: Convert timestamps to integer.
-        df_ok['start_time'] = df_ok['start_time'].astype(np.int64)
-        df_ok['end_time'] = df_ok['end_time'].astype(np.int64)
+        df_ok["start_time"] = df_ok["start_time"].astype(np.int64)
+        df_ok["end_time"] = df_ok["end_time"].astype(np.int64)
 
         # b) DataFrame.rolling().apply() only has access to one column at a time. Workaround: Move
         #    start_time to the index and pass the end_time series - including the index - to our
         #    function. This can be achieved by calling apply(..., raw=False).
-        df_ok = df_ok.set_index('start_time', append=True)
-        rolling = df_ok['end_time'].rolling(window, min_periods=2)
+        df_ok = df_ok.set_index("start_time", append=True)
+        rolling = df_ok["end_time"].rolling(window, min_periods=2)
         redundant = rolling.apply(is_redundant, raw=False).fillna(0).astype(np.bool)
-        redundant = redundant.reset_index('start_time', drop=True)
+        redundant = redundant.reset_index("start_time", drop=True)
 
         # So far we have operated on the qc-passed rows only. Update quality flags of rows in the
         # original (full) data frame.
         redundant = redundant[redundant.astype(np.bool)]
-        df.loc[redundant.index, 'global_quality_flag'] = QualityFlags.REDUNDANT
+        df.loc[redundant.index, "global_quality_flag"] = QualityFlags.REDUNDANT
 
     def _set_duplicate_flag(self, df):
         """Flag duplicate files in the given data frame.
@@ -276,9 +305,10 @@ class MetadataCollector:
         Two files are considered equal if platform, start- and end-time are identical. This happens
         if the same measurement has been transferred to two different ground stations.
         """
-        gs_dupl = df.duplicated(subset=['platform', 'start_time', 'end_time'],
-                                keep='first')
-        df.loc[gs_dupl, 'global_quality_flag'] = QualityFlags.DUPLICATE
+        gs_dupl = df.duplicated(
+            subset=["platform", "start_time", "end_time"], keep="first"
+        )
+        df.loc[gs_dupl, "global_quality_flag"] = QualityFlags.DUPLICATE
 
     def _set_invalid_timestamp_flag(self, df, platform):
         """Flag files with invalid timestamps.
@@ -288,27 +318,28 @@ class MetadataCollector:
         """
         valid_min, valid_max = TIME_COVERAGE[platform]
         if not valid_max:
-            valid_max = np.datetime64('2030-01-01 00:00')
+            valid_max = np.datetime64("2030-01-01 00:00")
         valid_min = np.datetime64(valid_min)
         valid_max = np.datetime64(valid_max)
-        out_of_range = ((df['start_time'] < valid_min) |
-                        (df['start_time'] > valid_max) |
-                        (df['end_time'] < valid_min) |
-                        (df['end_time'] > valid_max))
-        neg_dur = df['end_time'] < df['start_time']
+        out_of_range = (
+            (df["start_time"] < valid_min)
+            | (df["start_time"] > valid_max)
+            | (df["end_time"] < valid_min)
+            | (df["end_time"] > valid_max)
+        )
+        neg_dur = df["end_time"] < df["start_time"]
         invalid = neg_dur | out_of_range
-        df.loc[invalid, 'global_quality_flag'] = QualityFlags.INVALID_TIMESTAMP
+        df.loc[invalid, "global_quality_flag"] = QualityFlags.INVALID_TIMESTAMP
 
     def _set_too_short_flag(self, df):
         """Flag files considered too short.
 
         That means either not enough scanlines or duration is too short.
         """
-        too_short = (
-                (df['along_track'] < self.min_num_lines) |
-                (abs(df['end_time'] - df['start_time']) < self.min_duration)
+        too_short = (df["along_track"] < self.min_num_lines) | (
+            abs(df["end_time"] - df["start_time"]) < self.min_duration
         )
-        df.loc[too_short, 'global_quality_flag'] = QualityFlags.TOO_SHORT
+        df.loc[too_short, "global_quality_flag"] = QualityFlags.TOO_SHORT
 
     def _set_too_long_flag(self, df, max_length=120):
         """Flag files where (end_time - start_time) is unrealistically large.
@@ -320,9 +351,9 @@ class MetadataCollector:
             max_length: Maximum length (minutes) for a file to be considered ok. Otherwise it
                         will be flagged as too long.
         """
-        max_length = np.timedelta64(max_length, 'm')
-        too_long = (df['end_time'] - df['start_time']) > max_length
-        df.loc[too_long, 'global_quality_flag'] = QualityFlags.TOO_LONG
+        max_length = np.timedelta64(max_length, "m")
+        too_long = (df["end_time"] - df["start_time"]) > max_length
+        df.loc[too_long, "global_quality_flag"] = QualityFlags.TOO_LONG
 
     def _set_global_qual_flags(self, df, platform):
         """Set global quality flags."""
@@ -341,38 +372,40 @@ class MetadataCollector:
         subsequent files. Determine the overlap-free part of the file and set the corresponding
         overlap_free_start/end attributes.
         """
-        df_ok = df[df['global_quality_flag'] == QualityFlags.OK]
+        df_ok = df[df["global_quality_flag"] == QualityFlags.OK]
 
         for i in range(len(df_ok)):
             this_row = df_ok.iloc[i]
             prev_row = df_ok.iloc[i - 1] if i > 0 else None
             next_row = df_ok.iloc[i + 1] if i < len(df_ok) - 1 else None
-            LOG.debug('Computing overlap for {}'.format(this_row['filename']))
-            this_time = xr.open_dataset(this_row['filename'])['acq_time']
+            LOG.debug("Computing overlap for {}".format(this_row["filename"]))
+            this_time = xr.open_dataset(this_row["filename"])["acq_time"]
 
             # Compute overlap with preceding file
             if prev_row is not None:
-                if prev_row['end_time'] >= this_row['start_time']:
-                    prev_end_time = prev_row['end_time'].to_datetime64()
+                if prev_row["end_time"] >= this_row["start_time"]:
+                    prev_end_time = prev_row["end_time"].to_datetime64()
                     overlap_free_start = (this_time > prev_end_time).argmax().values
                 else:
                     overlap_free_start = 0
-                df.loc[df_ok.index[i], 'overlap_free_start'] = overlap_free_start
+                df.loc[df_ok.index[i], "overlap_free_start"] = overlap_free_start
             else:
                 # First file
-                df.loc[df_ok.index[i], 'overlap_free_start'] = 0
+                df.loc[df_ok.index[i], "overlap_free_start"] = 0
 
             # Compute overlap with subsequent file
             if next_row is not None:
-                if this_row['end_time'] >= next_row['start_time']:
-                    next_start_time = next_row['start_time'].to_datetime64()
-                    overlap_free_end = (this_time >= next_start_time).argmax().values - 1
+                if this_row["end_time"] >= next_row["start_time"]:
+                    next_start_time = next_row["start_time"].to_datetime64()
+                    overlap_free_end = (
+                        this_time >= next_start_time
+                    ).argmax().values - 1
                 else:
-                    overlap_free_end = this_row['along_track'] - 1
-                df.loc[df_ok.index[i], 'overlap_free_end'] = overlap_free_end
+                    overlap_free_end = this_row["along_track"] - 1
+                df.loc[df_ok.index[i], "overlap_free_end"] = overlap_free_end
             elif not open_end:
                 # Last file
-                df.loc[df_ok.index[i], 'overlap_free_end'] = this_row['along_track'] - 1
+                df.loc[df_ok.index[i], "overlap_free_end"] = this_row["along_track"] - 1
 
         return df
 
@@ -386,27 +419,39 @@ class MetadataUpdater:
         """
         mda = self._to_xarray(mda)
         mda = self._stack(mda)
-        for irow in range(mda.dims['row']):
+        for irow in range(mda.dims["row"]):
             row = mda.isel(row=irow)
-            LOG.debug('Updating metadata in {}'.format(row['filename'].item()))
-            with netCDF4.Dataset(filename=row['filename'].item(), mode='r+') as nc:
+            LOG.debug("Updating metadata in {}".format(row["filename"].item()))
+            with netCDF4.Dataset(filename=row["filename"].item(), mode="r+") as nc:
                 self._update_file(nc=nc, row=row)
 
     def _to_xarray(self, mda):
         """Convert pandas DataFrame to xarray Dataset."""
         mda = xr.Dataset(mda)
-        mda = mda.rename({'dim_0': 'row'})
+        mda = mda.rename({"dim_0": "row"})
         return mda
 
     def _stack(self, mda):
         """Stack certain columns to simplify the netCDF file."""
         # Stack equator crossing longitudes/times along a new dimension
-        mda['equator_crossing_time'] = (('row', 'num_eq_cross'), np.stack(
-            [mda['equator_crossing_time_1'].values,
-             mda['equator_crossing_time_2'].values]).transpose())
-        mda['equator_crossing_longitude'] = (('row', 'num_eq_cross'), np.stack(
-            [mda['equator_crossing_longitude_1'].values,
-             mda['equator_crossing_longitude_2'].values]).transpose())
+        mda["equator_crossing_time"] = (
+            ("row", "num_eq_cross"),
+            np.stack(
+                [
+                    mda["equator_crossing_time_1"].values,
+                    mda["equator_crossing_time_2"].values,
+                ]
+            ).transpose(),
+        )
+        mda["equator_crossing_longitude"] = (
+            ("row", "num_eq_cross"),
+            np.stack(
+                [
+                    mda["equator_crossing_longitude_1"].values,
+                    mda["equator_crossing_longitude_2"].values,
+                ]
+            ).transpose(),
+        )
         return mda
 
     def _create_nc_var(self, nc, var_name, fill_value, dtype, shape, dims):
@@ -421,35 +466,36 @@ class MetadataUpdater:
         if var_name in nc.variables:
             nc_var = nc.variables[var_name]
         else:
-            nc_var = nc.createVariable(var_name,
-                                       datatype=dtype,
-                                       fill_value=fill_value,
-                                       dimensions=dims)
+            nc_var = nc.createVariable(
+                var_name, datatype=dtype, fill_value=fill_value, dimensions=dims
+            )
         return nc_var
 
     def _update_file(self, nc, row):
         """Update metadata of a single file."""
         for add_mda in ADDITIONAL_METADATA:
             add_mda = add_mda.copy()
-            var_name = add_mda.pop('name')
-            fill_value = add_mda.pop('fill_value')
+            var_name = add_mda.pop("name")
+            fill_value = add_mda.pop("fill_value")
             data = row[var_name]
 
             # Create nc variable
-            nc_var = self._create_nc_var(nc=nc,
-                                         var_name=var_name,
-                                         fill_value=fill_value,
-                                         dtype=add_mda.pop('dtype'),
-                                         dims=data.dims,
-                                         shape=data.shape)
+            nc_var = self._create_nc_var(
+                nc=nc,
+                var_name=var_name,
+                fill_value=fill_value,
+                dtype=add_mda.pop("dtype"),
+                dims=data.dims,
+                shape=data.shape,
+            )
 
             # Write data to nc variable. Since netCDF4 cannot handle NaN nor NaT, disable
             # auto-masking, and set null-data to fill value manually.
             nc_var.set_auto_mask(False)
             if np.issubdtype(data.dtype, np.datetime64):
-                data, _, _ = encode_cf_datetime(data,
-                                                units=add_mda['units'],
-                                                calendar=add_mda['calendar'])
+                data, _, _ = encode_cf_datetime(
+                    data, units=add_mda["units"], calendar=add_mda["calendar"]
+                )
                 data = np.nan_to_num(data, nan=fill_value)
             else:
                 data = data.fillna(fill_value).values

--- a/pygac_fdr/metadata.py
+++ b/pygac_fdr/metadata.py
@@ -18,16 +18,16 @@
 
 """Collect and complement L1C metadata."""
 
+import logging
+import sqlite3
 from datetime import datetime
 from enum import IntEnum
-import logging
+
 import netCDF4
 import numpy as np
 import pandas as pd
-import sqlite3
 import xarray as xr
 from xarray.coding.times import encode_cf_datetime
-
 
 LOG = logging.getLogger(__package__)
 

--- a/pygac_fdr/reader.py
+++ b/pygac_fdr/reader.py
@@ -19,9 +19,9 @@
 """Read and calibrate AVHRR GAC level 1b data."""
 
 import os
+
 import satpy
 import trollsift
-
 
 BANDS = ['1', '2', '3', '3a', '3b', '4', '5']
 AUX_DATA = ['latitude',

--- a/pygac_fdr/reader.py
+++ b/pygac_fdr/reader.py
@@ -23,17 +23,21 @@ import os
 import satpy
 import trollsift
 
-BANDS = ['1', '2', '3', '3a', '3b', '4', '5']
-AUX_DATA = ['latitude',
-            'longitude',
-            'qual_flags',
-            'sensor_zenith_angle',
-            'solar_zenith_angle',
-            'solar_azimuth_angle',
-            'sensor_azimuth_angle',
-            'sun_sensor_azimuth_difference_angle']
-GAC_FORMAT = '{creation_site:3s}.{transfer_mode:4s}.{platform_id:2s}.D{start_time:%y%j.S%H%M}.' \
-             'E{end_time:%H%M}.B{orbit_number:05d}{end_orbit_last_digits:02d}.{station:2s}'
+BANDS = ["1", "2", "3", "3a", "3b", "4", "5"]
+AUX_DATA = [
+    "latitude",
+    "longitude",
+    "qual_flags",
+    "sensor_zenith_angle",
+    "solar_zenith_angle",
+    "solar_azimuth_angle",
+    "sensor_azimuth_angle",
+    "sun_sensor_azimuth_difference_angle",
+]
+GAC_FORMAT = (
+    "{creation_site:3s}.{transfer_mode:4s}.{platform_id:2s}.D{start_time:%y%j.S%H%M}."
+    "E{end_time:%H%M}.B{orbit_number:05d}{end_orbit_last_digits:02d}.{station:2s}"
+)
 
 
 def read_gac(filename, reader_kwargs=None):
@@ -45,20 +49,25 @@ def read_gac(filename, reader_kwargs=None):
     Returns:
         The loaded data in a satpy.Scene object.
     """
-    scene = satpy.Scene(filenames=[filename], reader='avhrr_l1b_gaclac',
-                        reader_kwargs=reader_kwargs)
+    scene = satpy.Scene(
+        filenames=[filename], reader="avhrr_l1b_gaclac", reader_kwargs=reader_kwargs
+    )
     scene.load(BANDS)
     scene.load(AUX_DATA)
 
     # Add additional metadata
     basename = os.path.basename(filename)
     fname_info = trollsift.parse(GAC_FORMAT, basename)
-    orbit_number_end = fname_info['orbit_number'] // 100 * 100 + fname_info['end_orbit_last_digits']
-    scene.attrs.update({
-        'gac_filename': basename,
-        'orbit_number_start': fname_info['orbit_number'],
-        'orbit_number_end': orbit_number_end,
-        'ground_station': fname_info['station']
-    })
+    orbit_number_end = (
+        fname_info["orbit_number"] // 100 * 100 + fname_info["end_orbit_last_digits"]
+    )
+    scene.attrs.update(
+        {
+            "gac_filename": basename,
+            "orbit_number_start": fname_info["orbit_number"],
+            "orbit_number_end": orbit_number_end,
+            "ground_station": fname_info["station"],
+        }
+    )
 
     return scene

--- a/pygac_fdr/tests/fetch_data.py
+++ b/pygac_fdr/tests/fetch_data.py
@@ -23,13 +23,13 @@ Existing files will only be re-downloaded if the server has a newer version.
 
 import logging
 import os
-from pathlib import Path
 import subprocess
+from pathlib import Path
 from urllib.parse import urlparse
+
 import yaml
 
-from pygac_fdr.utils import logging_on, LOGGER_NAME
-
+from pygac_fdr.utils import LOGGER_NAME, logging_on
 
 LOG = logging.getLogger(LOGGER_NAME)
 

--- a/pygac_fdr/tests/fetch_data.py
+++ b/pygac_fdr/tests/fetch_data.py
@@ -35,18 +35,27 @@ LOG = logging.getLogger(LOGGER_NAME)
 
 
 def fetch_test_data(url, target_dir):
-    LOG.info('Fetching test data')
+    LOG.info("Fetching test data")
     if not os.path.isdir(target_dir):
         os.makedirs(target_dir)
     url_p = urlparse(url)
-    cut_dirs = len(url_p.path.strip('/').split('/'))
-    cmd = ['wget', '--no-verbose', '--mirror', '--no-host-directories', '--no-parent', '--cut-dirs',
-           str(cut_dirs), '--reject="index.html*"', url]
+    cut_dirs = len(url_p.path.strip("/").split("/"))
+    cmd = [
+        "wget",
+        "--no-verbose",
+        "--mirror",
+        "--no-host-directories",
+        "--no-parent",
+        "--cut-dirs",
+        str(cut_dirs),
+        '--reject="index.html*"',
+        url,
+    ]
     subprocess.run(cmd, cwd=target_dir, check=True)
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     logging_on(logging.INFO)
-    with open(Path(__file__).parent / 'test_end2end.yaml') as fh:
+    with open(Path(__file__).parent / "test_end2end.yaml") as fh:
         config = yaml.safe_load(fh)
-    fetch_test_data(config['test_data_url'], config['test_data_dir'])
+    fetch_test_data(config["test_data_url"], config["test_data_dir"])

--- a/pygac_fdr/tests/test_end2end.py
+++ b/pygac_fdr/tests/test_end2end.py
@@ -30,23 +30,23 @@ Do not use pytest as this will eat up all your memory, because pytest caches all
 until the end of the test suite for some reason.
 """
 
-from cfchecker.cfchecks import CFChecker
-from dateutil.parser import isoparse
 import gzip
 import logging
-import numpy as np
-from pathlib import Path
 import shutil
 import subprocess
 import unittest
+from pathlib import Path
+
+import numpy as np
 import xarray as xr
-from xarray.core.utils import dict_equiv
-from xarray.core.formatting import diff_attrs_repr
 import yaml
+from cfchecker.cfchecks import CFChecker
+from dateutil.parser import isoparse
+from xarray.core.formatting import diff_attrs_repr
+from xarray.core.utils import dict_equiv
 
 from pygac_fdr.metadata import QualityFlags
-from pygac_fdr.utils import logging_on, LOGGER_NAME
-
+from pygac_fdr.utils import LOGGER_NAME, logging_on
 
 LOG = logging.getLogger(LOGGER_NAME)
 

--- a/pygac_fdr/tests/test_end2end.py
+++ b/pygac_fdr/tests/test_end2end.py
@@ -24,10 +24,14 @@ Usage:
 
 $ python test_end2end.py
 
+Or
+
+$ pytest -vs test_end2end.py
+
 The test behaviour can be controlled using the configuration file test_end2end.yaml .
 
-Do not use pytest as this will eat up all your memory, because pytest caches all generated figures
-until the end of the test suite for some reason.
+Do not use pytest in combination with plotting as this might eat up all your memory. For some
+reason pytest caches all generated figures until the end of the test suite.
 """
 
 import gzip

--- a/pygac_fdr/tests/test_end2end.py
+++ b/pygac_fdr/tests/test_end2end.py
@@ -56,7 +56,7 @@ class EndToEndTestBase(unittest.TestCase):
     with_metadata = False
 
     def _assert_time_attrs_close(self, attrs_a, attrs_b):
-        time_attrs = ['start_time', 'end_time']
+        time_attrs = ["start_time", "end_time"]
         for attr in time_attrs:
             with self.subTest(attribute=attr):
                 time_a = isoparse(attrs_a.pop(attr))
@@ -65,10 +65,10 @@ class EndToEndTestBase(unittest.TestCase):
 
     def _assert_numerical_attrs_close(self, attrs_a, attrs_b):
         numerical_attrs = [
-            'geospatial_lon_min',
-            'geospatial_lon_max',
-            'geospatial_lat_min',
-            'geospatial_lat_max',
+            "geospatial_lon_min",
+            "geospatial_lon_max",
+            "geospatial_lat_min",
+            "geospatial_lat_max",
         ]
         for attr in numerical_attrs:
             with self.subTest(attribute=attr):
@@ -81,43 +81,46 @@ class EndToEndTestBase(unittest.TestCase):
         attrs_b = b.attrs.copy()
         self._assert_time_attrs_close(attrs_a, attrs_b)
         self._assert_numerical_attrs_close(attrs_a, attrs_b)
-        assert dict_equiv(attrs_a, attrs_b), diff_attrs_repr(attrs_a, attrs_b, 'identical')
+        assert dict_equiv(attrs_a, attrs_b), diff_attrs_repr(
+            attrs_a, attrs_b, "identical"
+        )
 
     @classmethod
     def setUpClass(cls):
         logging_on(logging.DEBUG, for_all=True)
 
         # Read config file
-        with open(Path(__file__).parent / 'test_end2end.yaml') as fh:
+        with open(Path(__file__).parent / "test_end2end.yaml") as fh:
             config = yaml.safe_load(fh)
-        cls.test_data_dir = config['test_data_dir']
-        cls.cleanup = config['cleanup']
-        cls.resume = config['resume']
-        cls.fast = config['fast']
-        cls.rtol = float(config['rtol'])
-        cls.atol = float(config['atol'])
-        cls.plot = config['plot']
-        cls.trigger_failure = config['trigger_failure']
+        cls.test_data_dir = config["test_data_dir"]
+        cls.cleanup = config["cleanup"]
+        cls.resume = config["resume"]
+        cls.fast = config["fast"]
+        cls.rtol = float(config["rtol"])
+        cls.atol = float(config["atol"])
+        cls.plot = config["plot"]
+        cls.trigger_failure = config["trigger_failure"]
 
         # Set class attributes
-        cls.cfg_file = Path(__file__).absolute().parents[2] / 'etc' / 'pygac-fdr.yaml'
-        cls.tle_dir = Path(cls.test_data_dir) / 'tle'
-        cls.input_dir = Path(cls.test_data_dir) / 'input' / cls.tag
-        cls.output_dir = Path(cls.test_data_dir) / 'output' / cls.tag
-        cls.output_dir_ref = Path(cls.test_data_dir) / 'output_ref' / cls.tag
+        cls.cfg_file = Path(__file__).absolute().parents[2] / "etc" / "pygac-fdr.yaml"
+        cls.tle_dir = Path(cls.test_data_dir) / "tle"
+        cls.input_dir = Path(cls.test_data_dir) / "input" / cls.tag
+        cls.output_dir = Path(cls.test_data_dir) / "output" / cls.tag
+        cls.output_dir_ref = Path(cls.test_data_dir) / "output_ref" / cls.tag
 
         # Discover input files and reference output files
         cls.gac_files_gz, cls.nc_files_ref = cls._discover_files()
 
         # Process input files
-        dbfile = Path(cls.output_dir) / 'test.sqlite3'
-        cls.nc_files = cls._run(cls.gac_files_gz,
-                                dbfile=dbfile if cls.with_metadata else None)
+        dbfile = Path(cls.output_dir) / "test.sqlite3"
+        cls.nc_files = cls._run(
+            cls.gac_files_gz, dbfile=dbfile if cls.with_metadata else None
+        )
 
     @classmethod
     def _discover_files(cls):
-        gac_files_gz = sorted(Path(cls.input_dir).glob('*.gz'))
-        nc_files_ref = sorted(Path(cls.output_dir_ref).glob('*.nc'))
+        gac_files_gz = sorted(Path(cls.input_dir).glob("*.gz"))
+        nc_files_ref = sorted(Path(cls.output_dir_ref).glob("*.nc"))
         if cls.fast:
             gac_files_gz = [gac_files_gz[-1]]
             nc_files_ref = [nc_files_ref[-1]]
@@ -128,9 +131,8 @@ class EndToEndTestBase(unittest.TestCase):
         filenames = []
         for filename_gz in filenames_gz:
             filename = Path(output_dir) / filename_gz.stem
-            LOG.info('Decompressing {}'.format(filename_gz))
-            with gzip.open(filename_gz, 'rb') as f_in, \
-                 open(filename, 'wb') as f_out:
+            LOG.info("Decompressing {}".format(filename_gz))
+            with gzip.open(filename_gz, "rb") as f_in, open(filename, "wb") as f_out:
                 shutil.copyfileobj(f_in, f_out)
             filenames.append(filename)
         return filenames
@@ -143,8 +145,8 @@ class EndToEndTestBase(unittest.TestCase):
         """
         if cls.resume:
             # Resume testing with existing output files
-            LOG.info('Resuming test with existing output files')
-            return sorted(Path(cls.output_dir).glob('*.nc'))
+            LOG.info("Resuming test with existing output files")
+            return sorted(Path(cls.output_dir).glob("*.nc"))
 
         # Prepare output directory
         Path(cls.output_dir).mkdir(parents=True, exist_ok=True)
@@ -154,22 +156,34 @@ class EndToEndTestBase(unittest.TestCase):
         gac_files = cls._unzip_gac_files(gac_files_gz, cls.output_dir)
 
         # Read GAC files and write netCDF files
-        run = ['pygac-fdr-run',
-               '--cfg', cls.cfg_file,
-               '--output-dir', cls.output_dir,
-               '--tle-dir', cls.tle_dir,
-               '--verbose', '--log-all'] + gac_files
+        run = [
+            "pygac-fdr-run",
+            "--cfg",
+            cls.cfg_file,
+            "--output-dir",
+            cls.output_dir,
+            "--tle-dir",
+            cls.tle_dir,
+            "--verbose",
+            "--log-all",
+        ] + gac_files
         subprocess.run(run, check=True)
-        nc_files = sorted(Path(cls.output_dir).glob('*.nc'))
+        nc_files = sorted(Path(cls.output_dir).glob("*.nc"))
 
         if dbfile:
             # Collect & complement metadata
-            collect = ['pygac-fdr-mda-collect', '--dbfile', dbfile, '--if-exists', 'replace',
-                       '--verbose'] + nc_files
+            collect = [
+                "pygac-fdr-mda-collect",
+                "--dbfile",
+                dbfile,
+                "--if-exists",
+                "replace",
+                "--verbose",
+            ] + nc_files
             subprocess.run(collect, check=True)
 
             # Update metadata
-            update = ['pygac-fdr-mda-update', '--dbfile', dbfile]
+            update = ["pygac-fdr-mda-update", "--dbfile", dbfile]
             subprocess.run(update, check=True)
 
         return nc_files
@@ -187,13 +201,18 @@ class EndToEndTestBase(unittest.TestCase):
 
     def _tst_regression(self, nc_files, nc_files_ref):
         """Test entire netCDF contents against reference file."""
-        dynamic_attrs = ['date_created', 'history', 'version_satpy', 'version_pygac',
-                         'version_pygac_fdr']
+        dynamic_attrs = [
+            "date_created",
+            "history",
+            "version_satpy",
+            "version_pygac",
+            "version_pygac_fdr",
+        ]
         for nc_file, nc_file_ref in zip(nc_files, nc_files_ref):
-            LOG.info('Performing regression test with {}'.format(nc_file))
-            with self.subTest(nc_file=nc_file), \
-                 xr.open_dataset(nc_file, chunks=1024) as ds, \
-                 xr.open_dataset(nc_file_ref, chunks=1024) as ds_ref:
+            LOG.info("Performing regression test with {}".format(nc_file))
+            with self.subTest(nc_file=nc_file), xr.open_dataset(
+                nc_file, chunks=1024
+            ) as ds, xr.open_dataset(nc_file_ref, chunks=1024) as ds_ref:
 
                 # Remove dynamic attributes
                 for attr in dynamic_attrs:
@@ -202,20 +221,24 @@ class EndToEndTestBase(unittest.TestCase):
 
                 # If testing just one file, there is no overlap
                 if self.fast:
-                    ds = ds.drop_vars(['overlap_free_start', 'overlap_free_end'],
-                                      errors='ignore')
-                    ds_ref = ds_ref.drop_vars(['overlap_free_start', 'overlap_free_end'],
-                                              errors='ignore')
+                    ds = ds.drop_vars(
+                        ["overlap_free_start", "overlap_free_end"], errors="ignore"
+                    )
+                    ds_ref = ds_ref.drop_vars(
+                        ["overlap_free_start", "overlap_free_end"], errors="ignore"
+                    )
 
                 # Trigger test failure
                 if self.trigger_failure:
-                    ds['latitude'] = ds['latitude'] * 2
-                    ds.attrs['geospatial_lat_min'] = 9999.0
+                    ds["latitude"] = ds["latitude"] * 2
+                    ds.attrs["geospatial_lat_min"] = 9999.0
 
                 # Compare datasets
                 self.assert_attrs_close(ds, ds_ref)
                 try:
-                    xr.testing.assert_allclose(ds, ds_ref, atol=self.atol, rtol=self.rtol)
+                    xr.testing.assert_allclose(
+                        ds, ds_ref, atol=self.atol, rtol=self.rtol
+                    )
                 except AssertionError:
                     if self.plot:
                         self._plot_diffs(ds_ref=ds_ref, ds_tst=ds, file_tst=nc_file)
@@ -226,20 +249,20 @@ class EndToEndTestBase(unittest.TestCase):
         import matplotlib.pyplot as plt
 
         cmp_vars = {
-            'reflectance_channel_1': {},
-            'reflectance_channel_2': {},
-            'brightness_temperature_channel_3': {},
-            'reflectance_channel_3a': {},
-            'brightness_temperature_channel_3b': {},
-            'brightness_temperature_channel_4': {},
-            'brightness_temperature_channel_5': {},
-            'longitude': {'vmin': -180, 'vmax': 180},
-            'latitude': {'vmin': -90, 'vmax': 90},
-            'solar_zenith_angle': {},
-            'solar_azimuth_angle': {},
-            'sensor_zenith_angle': {},
-            'sensor_azimuth_angle': {},
-            'sun_sensor_azimuth_difference_angle': {},
+            "reflectance_channel_1": {},
+            "reflectance_channel_2": {},
+            "brightness_temperature_channel_3": {},
+            "reflectance_channel_3a": {},
+            "brightness_temperature_channel_3b": {},
+            "brightness_temperature_channel_4": {},
+            "brightness_temperature_channel_5": {},
+            "longitude": {"vmin": -180, "vmax": 180},
+            "latitude": {"vmin": -90, "vmax": 90},
+            "solar_zenith_angle": {},
+            "solar_azimuth_angle": {},
+            "sensor_zenith_angle": {},
+            "sensor_azimuth_angle": {},
+            "sun_sensor_azimuth_difference_angle": {},
         }
 
         for varname, prop in cmp_vars.items():
@@ -253,29 +276,32 @@ class EndToEndTestBase(unittest.TestCase):
             max_diff = diff.max()
             abs_max_diff = max(abs(min_diff), abs(max_diff))
 
-            fig, (ax_ref, ax_tst, ax_diff) = plt.subplots(nrows=3,
-                                                          figsize=(20, 8.5),
-                                                          sharex=True)
+            fig, (ax_ref, ax_tst, ax_diff) = plt.subplots(
+                nrows=3, figsize=(20, 8.5), sharex=True
+            )
             ds_ref[varname].transpose().plot.imshow(
-                ax=ax_ref, vmin=prop.get('vmin', vmin), vmax=prop.get('vmax', vmax)
+                ax=ax_ref, vmin=prop.get("vmin", vmin), vmax=prop.get("vmax", vmax)
             )
             ds_tst[varname].transpose().plot.imshow(
-                ax=ax_tst, vmin=prop.get('vmin', vmin), vmax=prop.get('vmax', vmax)
+                ax=ax_tst, vmin=prop.get("vmin", vmin), vmax=prop.get("vmax", vmax)
             )
             diff.transpose().plot.imshow(
-                ax=ax_diff, vmin=-0.8 * abs_max_diff, vmax=0.8 * abs_max_diff, cmap='RdBu_r'
+                ax=ax_diff,
+                vmin=-0.8 * abs_max_diff,
+                vmax=0.8 * abs_max_diff,
+                cmap="RdBu_r",
             )
 
-            ax_ref.set_title('Reference', fontsize=10)
-            ax_tst.set_title('Test', fontsize=10)
-            ax_diff.set_title('Test - Reference', fontsize=10)
+            ax_ref.set_title("Reference", fontsize=10)
+            ax_tst.set_title("Test", fontsize=10)
+            ax_diff.set_title("Test - Reference", fontsize=10)
             ax_ref.set_xlabel(None)
             ax_tst.set_xlabel(None)
             plt.suptitle(Path(file_tst).name)
 
-            ofile = '{}_{}.png'.format(Path(file_tst).name, varname)
-            plt.savefig(Path(self.output_dir) / ofile, bbox_inches='tight')
-            plt.close('all')
+            ofile = "{}_{}.png".format(Path(file_tst).name, varname)
+            plt.savefig(Path(self.output_dir) / ofile, bbox_inches="tight")
+            plt.close("all")
 
 
 class EndToEndTestNormal(EndToEndTestBase):
@@ -284,121 +310,121 @@ class EndToEndTestNormal(EndToEndTestBase):
     Also compare metadata against results from CLARA-A3 feedback loop 1.
     """
 
-    tag = 'normal'
+    tag = "normal"
     with_metadata = True
     mda_exp = {
-        'NSS.GHRR.NA.D81089.S0054.E0246.B0912021.GC': {
-            'nc_file': 'AVHRR-GAC_FDR_1C_N06_19810330T005421Z_19810330T024632Z_R_O_20200101T000000Z_0100.nc',
-            'midnight_line': np.nan,
-            'overlap_free_end': 12995,
-            'global_quality_flag': QualityFlags.OK
+        "NSS.GHRR.NA.D81089.S0054.E0246.B0912021.GC": {
+            "nc_file": "AVHRR-GAC_FDR_1C_N06_19810330T005421Z_19810330T024632Z_R_O_20200101T000000Z_0100.nc",
+            "midnight_line": np.nan,
+            "overlap_free_end": 12995,
+            "global_quality_flag": QualityFlags.OK,
         },
-        'NSS.GHRR.NA.D81089.S0242.E0427.B0912122.GC': {
-            'nc_file': 'AVHRR-GAC_FDR_1C_N06_19810330T024239Z_19810330T042759Z_R_O_20200101T000000Z_0100.nc',
-            'midnight_line': np.nan,
-            'overlap_free_end': 12157,
-            'global_quality_flag': QualityFlags.OK
+        "NSS.GHRR.NA.D81089.S0242.E0427.B0912122.GC": {
+            "nc_file": "AVHRR-GAC_FDR_1C_N06_19810330T024239Z_19810330T042759Z_R_O_20200101T000000Z_0100.nc",
+            "midnight_line": np.nan,
+            "overlap_free_end": 12157,
+            "global_quality_flag": QualityFlags.OK,
         },
-        'NSS.GHRR.NA.D81089.S0423.E0609.B0912223.GC': {
-            'nc_file': 'AVHRR-GAC_FDR_1C_N06_19810330T042358Z_19810330T060903Z_R_O_20200101T000000Z_0100.nc',
-            'midnight_line': np.nan,
-            'overlap_free_end': 12100,
+        "NSS.GHRR.NA.D81089.S0423.E0609.B0912223.GC": {
+            "nc_file": "AVHRR-GAC_FDR_1C_N06_19810330T042358Z_19810330T060903Z_R_O_20200101T000000Z_0100.nc",
+            "midnight_line": np.nan,
+            "overlap_free_end": 12100,
             # 12602 (=along_track-1) in CLARA, but that's because the next file was skipped
             # for some reason
-            'global_quality_flag': QualityFlags.OK
+            "global_quality_flag": QualityFlags.OK,
         },
-        'NSS.GHRR.NA.D81089.S0604.E0758.B0912324.WI': {
-            'nc_file': 'AVHRR-GAC_FDR_1C_N06_19810330T060453Z_19810330T075842Z_R_O_20200101T000000Z_0100.nc',
-            'midnight_line': np.nan,
-            'overlap_free_end': 13020,  # Skipped in CLARA
-            'global_quality_flag': QualityFlags.OK
+        "NSS.GHRR.NA.D81089.S0604.E0758.B0912324.WI": {
+            "nc_file": "AVHRR-GAC_FDR_1C_N06_19810330T060453Z_19810330T075842Z_R_O_20200101T000000Z_0100.nc",
+            "midnight_line": np.nan,
+            "overlap_free_end": 13020,  # Skipped in CLARA
+            "global_quality_flag": QualityFlags.OK,
         },
-        'NSS.GHRR.NA.D81089.S0753.E0947.B0912425.WI': {
-            'nc_file': 'AVHRR-GAC_FDR_1C_N06_19810330T075339Z_19810330T094742Z_R_O_20200101T000000Z_0100.nc',
-            'midnight_line': np.nan,
-            'overlap_free_end': 13053,
+        "NSS.GHRR.NA.D81089.S0753.E0947.B0912425.WI": {
+            "nc_file": "AVHRR-GAC_FDR_1C_N06_19810330T075339Z_19810330T094742Z_R_O_20200101T000000Z_0100.nc",
+            "midnight_line": np.nan,
+            "overlap_free_end": 13053,
             # 13618 (=along_track-1) in CLARA, but that's because only the next file
             # (redundant in this case) is taken into account. It is not taken into
             # account that there might be overlap with the file after that.
-            'global_quality_flag': QualityFlags.OK
+            "global_quality_flag": QualityFlags.OK,
         },
-        'NSS.GHRR.NA.D81089.S0943.E1058.B0912525.WI': {
-            'nc_file': 'AVHRR-GAC_FDR_1C_N06_19810330T094300Z_19810330T105846Z_R_O_20200101T000000Z_0100.nc',
-            'midnight_line': np.nan,
-            'overlap_free_end': np.nan,
-            'global_quality_flag': QualityFlags.REDUNDANT
+        "NSS.GHRR.NA.D81089.S0943.E1058.B0912525.WI": {
+            "nc_file": "AVHRR-GAC_FDR_1C_N06_19810330T094300Z_19810330T105846Z_R_O_20200101T000000Z_0100.nc",
+            "midnight_line": np.nan,
+            "overlap_free_end": np.nan,
+            "global_quality_flag": QualityFlags.REDUNDANT,
         },
-        'NSS.GHRR.NA.D81089.S0943.E1136.B0912526.WI': {
-            'nc_file': 'AVHRR-GAC_FDR_1C_N06_19810330T094300Z_19810330T113615Z_R_O_20200101T000000Z_0100.nc',
-            'midnight_line': np.nan,
-            'overlap_free_end': 12989,  # Skipped in CLARA
-            'global_quality_flag': QualityFlags.OK
+        "NSS.GHRR.NA.D81089.S0943.E1136.B0912526.WI": {
+            "nc_file": "AVHRR-GAC_FDR_1C_N06_19810330T094300Z_19810330T113615Z_R_O_20200101T000000Z_0100.nc",
+            "midnight_line": np.nan,
+            "overlap_free_end": 12989,  # Skipped in CLARA
+            "global_quality_flag": QualityFlags.OK,
         },
-        'NSS.GHRR.NA.D81089.S1102.E1136.B0912626.WI': {
-            'nc_file': 'AVHRR-GAC_FDR_1C_N06_19810330T110243Z_19810330T113615Z_R_O_20200101T000000Z_0100.nc',
-            'midnight_line': np.nan,
-            'overlap_free_end': np.nan,
-            'global_quality_flag': QualityFlags.REDUNDANT
+        "NSS.GHRR.NA.D81089.S1102.E1136.B0912626.WI": {
+            "nc_file": "AVHRR-GAC_FDR_1C_N06_19810330T110243Z_19810330T113615Z_R_O_20200101T000000Z_0100.nc",
+            "midnight_line": np.nan,
+            "overlap_free_end": np.nan,
+            "global_quality_flag": QualityFlags.REDUNDANT,
         },
-        'NSS.GHRR.NA.D81089.S1131.E1205.B0912626.WI': {
-            'nc_file': 'AVHRR-GAC_FDR_1C_N06_19810330T113119Z_19810330T120530Z_R_O_20200101T000000Z_0100.nc',
-            'midnight_line': np.nan,
-            'overlap_free_end': 3222,  # == along_track - 1
+        "NSS.GHRR.NA.D81089.S1131.E1205.B0912626.WI": {
+            "nc_file": "AVHRR-GAC_FDR_1C_N06_19810330T113119Z_19810330T120530Z_R_O_20200101T000000Z_0100.nc",
+            "midnight_line": np.nan,
+            "overlap_free_end": 3222,  # == along_track - 1
             # 3232 (== along_track - 1) in CLARA. The file is just a bit longer there
             # (+4 seconds, 3233 lines. Not sure why...
-            'global_quality_flag': QualityFlags.OK
+            "global_quality_flag": QualityFlags.OK,
         },
-        'NSS.GHRR.NA.D81089.S1221.E1315.B0912627.WI': {
-            'nc_file': 'AVHRR-GAC_FDR_1C_N06_19810330T122303Z_19810330T131503Z_R_O_20200101T000000Z_0100.nc',
-            'midnight_line': np.nan,
-            'overlap_free_end': 6198,  # == along_track -1
+        "NSS.GHRR.NA.D81089.S1221.E1315.B0912627.WI": {
+            "nc_file": "AVHRR-GAC_FDR_1C_N06_19810330T122303Z_19810330T131503Z_R_O_20200101T000000Z_0100.nc",
+            "midnight_line": np.nan,
+            "overlap_free_end": 6198,  # == along_track -1
             # 6193 (== along_track - 1) in CLARA. The file is just a bit shorter there
             # (-1.5 seconds, 6194 lines in total). Not sure why...
-            'global_quality_flag': QualityFlags.OK
+            "global_quality_flag": QualityFlags.OK,
         },
-        'NSS.GHRR.NA.D81089.S1329.E1459.B0912728.WI': {
-            'nc_file': 'AVHRR-GAC_FDR_1C_N06_19810330T132910Z_19810330T145933Z_R_O_20200101T000000Z_0100.nc',
-            'midnight_line': np.nan,
-            'overlap_free_end': 10770,
-            'global_quality_flag': QualityFlags.OK
+        "NSS.GHRR.NA.D81089.S1329.E1459.B0912728.WI": {
+            "nc_file": "AVHRR-GAC_FDR_1C_N06_19810330T132910Z_19810330T145933Z_R_O_20200101T000000Z_0100.nc",
+            "midnight_line": np.nan,
+            "overlap_free_end": 10770,
+            "global_quality_flag": QualityFlags.OK,
         },
-        'NSS.GHRR.NA.D81089.S1459.E1631.B0912829.GC': {
-            'nc_file': 'AVHRR-GAC_FDR_1C_N06_19810330T145914Z_19810330T163142Z_R_O_20200101T000000Z_0100.nc',
-            'midnight_line': np.nan,
-            'overlap_free_end': 10489,
-            'global_quality_flag': QualityFlags.OK
+        "NSS.GHRR.NA.D81089.S1459.E1631.B0912829.GC": {
+            "nc_file": "AVHRR-GAC_FDR_1C_N06_19810330T145914Z_19810330T163142Z_R_O_20200101T000000Z_0100.nc",
+            "midnight_line": np.nan,
+            "overlap_free_end": 10489,
+            "global_quality_flag": QualityFlags.OK,
         },
-        'NSS.GHRR.NA.D81089.S1626.E1812.B0912930.GC': {
-            'nc_file': 'AVHRR-GAC_FDR_1C_N06_19810330T162639Z_19810330T181201Z_R_O_20200101T000000Z_0100.nc',
-            'midnight_line': np.nan,
-            'overlap_free_end': 12057,
-            'global_quality_flag': QualityFlags.OK
+        "NSS.GHRR.NA.D81089.S1626.E1812.B0912930.GC": {
+            "nc_file": "AVHRR-GAC_FDR_1C_N06_19810330T162639Z_19810330T181201Z_R_O_20200101T000000Z_0100.nc",
+            "midnight_line": np.nan,
+            "overlap_free_end": 12057,
+            "global_quality_flag": QualityFlags.OK,
         },
-        'NSS.GHRR.NA.D81089.S1807.E1951.B0913031.GC': {
-            'nc_file': 'AVHRR-GAC_FDR_1C_N06_19810330T180708Z_19810330T195132Z_R_O_20200101T000000Z_0100.nc',
-            'midnight_line': np.nan,
-            'overlap_free_end': 12011,
-            'global_quality_flag': QualityFlags.OK
+        "NSS.GHRR.NA.D81089.S1807.E1951.B0913031.GC": {
+            "nc_file": "AVHRR-GAC_FDR_1C_N06_19810330T180708Z_19810330T195132Z_R_O_20200101T000000Z_0100.nc",
+            "midnight_line": np.nan,
+            "overlap_free_end": 12011,
+            "global_quality_flag": QualityFlags.OK,
         },
-        'NSS.GHRR.NA.D81089.S1947.E2131.B0913132.GC': {
-            'nc_file': 'AVHRR-GAC_FDR_1C_N06_19810330T194718Z_19810330T213158Z_R_O_20200101T000000Z_0100.nc',
-            'midnight_line': np.nan,
-            'overlap_free_end': 11955,
-            'global_quality_flag': QualityFlags.OK
+        "NSS.GHRR.NA.D81089.S1947.E2131.B0913132.GC": {
+            "nc_file": "AVHRR-GAC_FDR_1C_N06_19810330T194718Z_19810330T213158Z_R_O_20200101T000000Z_0100.nc",
+            "midnight_line": np.nan,
+            "overlap_free_end": 11955,
+            "global_quality_flag": QualityFlags.OK,
         },
-        'NSS.GHRR.NA.D81089.S2126.E2256.B0913233.WI': {
-            'nc_file': 'AVHRR-GAC_FDR_1C_N06_19810330T212656Z_19810330T225612Z_R_O_20200101T000000Z_0100.nc',
-            'midnight_line': np.nan,
-            'overlap_free_end': 10057,
-            'global_quality_flag': QualityFlags.OK
+        "NSS.GHRR.NA.D81089.S2126.E2256.B0913233.WI": {
+            "nc_file": "AVHRR-GAC_FDR_1C_N06_19810330T212656Z_19810330T225612Z_R_O_20200101T000000Z_0100.nc",
+            "midnight_line": np.nan,
+            "overlap_free_end": 10057,
+            "global_quality_flag": QualityFlags.OK,
         },
-        'NSS.GHRR.NA.D81089.S2251.E0035.B0913334.WI': {
-            'nc_file': 'AVHRR-GAC_FDR_1C_N06_19810330T225108Z_19810331T003506Z_R_O_20200101T000000Z_0100.nc',
-            'midnight_line': 8260,
-            'overlap_free_end': 12472,
+        "NSS.GHRR.NA.D81089.S2251.E0035.B0913334.WI": {
+            "nc_file": "AVHRR-GAC_FDR_1C_N06_19810330T225108Z_19810331T003506Z_R_O_20200101T000000Z_0100.nc",
+            "midnight_line": 8260,
+            "overlap_free_end": 12472,
             # This is the last file here, therefore overlap_free_end == along_track - 1.
             # In CLARA there is overlap with the next file, which is why they have 12101.
-            'global_quality_flag': QualityFlags.OK
+            "global_quality_flag": QualityFlags.OK,
         },
     }  # from CLARA-A3 Feedback Loop 1
 
@@ -409,9 +435,9 @@ class EndToEndTestNormal(EndToEndTestBase):
         """Test metadata against CLARA-A3 reference."""
         for nc_file in self.nc_files:
             with xr.open_dataset(nc_file) as ds:
-                gac_file = ds.attrs['gac_filename']
+                gac_file = ds.attrs["gac_filename"]
                 mda_exp = self.mda_exp[gac_file].copy()
-                mda_exp.pop('nc_file')
+                mda_exp.pop("nc_file")
                 for var_name, exp in mda_exp.items():
                     np.testing.assert_equal(ds[var_name].values, exp)
 
@@ -419,23 +445,25 @@ class EndToEndTestNormal(EndToEndTestBase):
         """Test CF compliance of generated files using CF checker."""
         checker = CFChecker()
         for nc_file in self.nc_files:
-            LOG.info('Checking CF compliance of {}'.format(nc_file))
+            LOG.info("Checking CF compliance of {}".format(nc_file))
             res = checker.checker(str(nc_file))
-            global_err = any([res['global'][cat] for cat in ('ERROR', 'FATAL')])
-            var_err = any([(v['ERROR'] or v['FATAL']) for v in res['variables'].values()])
+            global_err = any([res["global"][cat] for cat in ("ERROR", "FATAL")])
+            var_err = any(
+                [(v["ERROR"] or v["FATAL"]) for v in res["variables"].values()]
+            )
             err = global_err or var_err
-            self.assertFalse(err, msg='{} is not CF compliant'.format(nc_file))
+            self.assertFalse(err, msg="{} is not CF compliant".format(nc_file))
 
 
 class EndToEndTestCorrupt(EndToEndTestBase):
     """End-to-end test with data that have common defects."""
 
-    tag = 'corrupt'
+    tag = "corrupt"
     with_metadata = False
 
     def test_regression(self):
         self._tst_regression(self.nc_files, self.nc_files_ref)
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     unittest.main(verbosity=2)

--- a/pygac_fdr/tests/test_metadata.py
+++ b/pygac_fdr/tests/test_metadata.py
@@ -16,13 +16,14 @@
 # You should have received a copy of the GNU General Public License along with
 # pygac-fdr. If not, see <http://www.gnu.org/licenses/>.
 
-import numpy as np
-import pandas as pd
 import unittest
 from unittest import mock
+
+import numpy as np
+import pandas as pd
 import xarray as xr
 
-from pygac_fdr.metadata import QualityFlags, MetadataCollector
+from pygac_fdr.metadata import MetadataCollector, QualityFlags
 
 
 def open_dataset_patched(filename):

--- a/pygac_fdr/tests/test_metadata.py
+++ b/pygac_fdr/tests/test_metadata.py
@@ -28,186 +28,219 @@ from pygac_fdr.metadata import MetadataCollector, QualityFlags
 
 def open_dataset_patched(filename):
     times = {
-        'file3': [np.datetime64('2009-07-01 00:00'),
-                  np.datetime64('2009-07-01 00:30'),
-                  np.datetime64('2009-07-01 00:45'),
-                  np.datetime64('2009-07-01 00:55'),
-                  np.datetime64('2009-07-01 01:00')],
-        'file4': [np.datetime64('2009-07-01 00:50'),
-                  np.datetime64('2009-07-01 01:00'),
-                  np.datetime64('2009-07-01 01:30'),
-                  np.datetime64('2009-07-01 01:49'),
-                  np.datetime64('2009-07-01 02:00')],
-        'file5': [np.datetime64('2009-07-01 01:50'),
-                  np.datetime64('2009-07-01 02:01'),
-                  np.datetime64('2009-07-01 02:30'),
-                  np.datetime64('2009-07-01 02:51'),
-                  np.datetime64('2009-07-01 03:00')],
-        'file9': [np.datetime64('2009-07-01 02:50'),
-                  np.datetime64('2009-07-01 03:00'),
-                  np.datetime64('2009-07-01 03:15'),
-                  np.datetime64('2009-07-01 03:45'),
-                  np.datetime64('2009-07-01 04:00')]
+        "file3": [
+            np.datetime64("2009-07-01 00:00"),
+            np.datetime64("2009-07-01 00:30"),
+            np.datetime64("2009-07-01 00:45"),
+            np.datetime64("2009-07-01 00:55"),
+            np.datetime64("2009-07-01 01:00"),
+        ],
+        "file4": [
+            np.datetime64("2009-07-01 00:50"),
+            np.datetime64("2009-07-01 01:00"),
+            np.datetime64("2009-07-01 01:30"),
+            np.datetime64("2009-07-01 01:49"),
+            np.datetime64("2009-07-01 02:00"),
+        ],
+        "file5": [
+            np.datetime64("2009-07-01 01:50"),
+            np.datetime64("2009-07-01 02:01"),
+            np.datetime64("2009-07-01 02:30"),
+            np.datetime64("2009-07-01 02:51"),
+            np.datetime64("2009-07-01 03:00"),
+        ],
+        "file9": [
+            np.datetime64("2009-07-01 02:50"),
+            np.datetime64("2009-07-01 03:00"),
+            np.datetime64("2009-07-01 03:15"),
+            np.datetime64("2009-07-01 03:45"),
+            np.datetime64("2009-07-01 04:00"),
+        ],
     }
-    times = dict([(fname, xr.Dataset({'acq_time': time}))
-                  for fname, time in times.items()])
-    return times.get(filename, xr.Dataset({'acq_time': [0]}))
+    times = dict(
+        [(fname, xr.Dataset({"acq_time": time})) for fname, time in times.items()]
+    )
+    return times.get(filename, xr.Dataset({"acq_time": [0]}))
 
 
 class MetadataCollectorTest(unittest.TestCase):
     def get_mda(self, multi_platform=False):
         mda = [
-            {'platform': 'NOAA-16',
-             'start_time': np.datetime64('2020-01-01 12:00'),
-             'end_time': np.datetime64('2020-01-01 13:00'),
-             'along_track': 12000,
-             'filename': 'file1',
-             'midnight_scanline': 1234,
-             'overlap_free_start': np.nan,
-             'overlap_free_start_exp': np.nan,
-             'overlap_free_end': np.nan,
-             'overlap_free_end_exp': np.nan,
-             'global_quality_flag': QualityFlags.OK,
-             'global_quality_flag_exp': QualityFlags.INVALID_TIMESTAMP},
-            {'platform': 'NOAA-16',
-             'start_time': np.datetime64('2009-06-30'),
-             'end_time': np.datetime64('2049-01-01'),
-             'along_track': 12000,
-             'filename': 'file2',
-             'midnight_scanline': 1234,
-             'overlap_free_start': np.nan,
-             'overlap_free_start_exp': np.nan,
-             'overlap_free_end': np.nan,
-             'overlap_free_end_exp': np.nan,
-             'global_quality_flag': QualityFlags.OK,
-             'global_quality_flag_exp': QualityFlags.TOO_LONG},
-            {'platform': 'NOAA-16',
-             'start_time': np.datetime64('2009-07-01 00:00'),
-             'end_time': np.datetime64('2009-07-01 01:00'),
-             'along_track': 12000,
-             'filename': 'file3',
-             'midnight_scanline': 1234,
-             'overlap_free_start': np.nan,
-             'overlap_free_start_exp': 0,
-             'overlap_free_end': np.nan,
-             'overlap_free_end_exp': 2,
-             'global_quality_flag': QualityFlags.OK,
-             'global_quality_flag_exp': QualityFlags.OK},
-            {'platform': 'NOAA-16',
-             'start_time': np.datetime64('2009-07-01 00:50'),
-             'end_time': np.datetime64('2009-07-01 02:00'),
-             'along_track': 12000,
-             'filename': 'file4',
-             'midnight_scanline': 1234,
-             'overlap_free_start': np.nan,
-             'overlap_free_start_exp': 2,
-             'overlap_free_end': np.nan,
-             'overlap_free_end_exp': 3,
-             'global_quality_flag': QualityFlags.OK,
-             'global_quality_flag_exp': QualityFlags.OK},
-            {'platform': 'NOAA-16',
-             'start_time': np.datetime64('2009-07-01 01:50'),
-             'end_time': np.datetime64('2009-07-01 03:00'),
-             'along_track': 12000,
-             'filename': 'file5',
-             'midnight_scanline': 1234,
-             'overlap_free_start': np.nan,
-             'overlap_free_start_exp': 1,
-             'overlap_free_end': np.nan,
-             'overlap_free_end_exp': 2,
-             'global_quality_flag': QualityFlags.OK,
-             'global_quality_flag_exp': QualityFlags.OK},
-            {'platform': 'NOAA-16',
-             'start_time': np.datetime64('2009-07-01 02:15'),
-             'end_time': np.datetime64('2009-07-01 02:30'),
-             'along_track': 12000,
-             'filename': 'file6',
-             'midnight_scanline': 1234,
-             'overlap_free_start': np.nan,
-             'overlap_free_start_exp': np.nan,
-             'overlap_free_end': np.nan,
-             'overlap_free_end_exp': np.nan,
-             'global_quality_flag': QualityFlags.OK,
-             'global_quality_flag_exp': QualityFlags.REDUNDANT},
-            {'platform': 'NOAA-16',
-             'start_time': np.datetime64('2009-07-01 02:15'),
-             'end_time': np.datetime64('2009-07-01 02:30'),
-             'along_track': 12000,
-             'filename': 'file7',
-             'midnight_scanline': 1234,
-             'overlap_free_start': np.nan,
-             'overlap_free_start_exp': np.nan,
-             'overlap_free_end': np.nan,
-             'overlap_free_end_exp': np.nan,
-             'global_quality_flag': QualityFlags.OK,
-             'global_quality_flag_exp': QualityFlags.DUPLICATE},
-            {'platform': 'NOAA-16',
-             'start_time': np.datetime64('2009-07-01 03:00'),
-             'end_time': np.datetime64('2009-07-01 03:01'),
-             'along_track': 49,
-             'filename': 'file8',
-             'midnight_scanline': 1234,
-             'overlap_free_start': np.nan,
-             'overlap_free_start_exp': np.nan,
-             'overlap_free_end': np.nan,
-             'overlap_free_end_exp': np.nan,
-             'global_quality_flag': QualityFlags.OK,
-             'global_quality_flag_exp': QualityFlags.TOO_SHORT},
-            {'platform': 'NOAA-16',
-             'start_time': np.datetime64('2009-07-01 02:50'),
-             'end_time': np.datetime64('2009-07-01 04:00'),
-             'along_track': 12000,
-             'filename': 'file9',
-             'midnight_scanline': 1234,
-             'overlap_free_start': np.nan,
-             'overlap_free_start_exp': 2,
-             'overlap_free_end': np.nan,
-             'overlap_free_end_exp': 11999,
-             'global_quality_flag': QualityFlags.OK,
-             'global_quality_flag_exp': QualityFlags.OK},
-            {'platform': 'NOAA-16',
-             'start_time': np.datetime64('2009-07-01 03:50'),
-             'end_time': np.datetime64('2008-07-01 05:00'),
-             'along_track': 12000,
-             'filename': 'file10',
-             'midnight_scanline': 1234,
-             'overlap_free_start': np.nan,
-             'overlap_free_start_exp': np.nan,
-             'overlap_free_end': np.nan,
-             'overlap_free_end_exp': np.nan,
-             'global_quality_flag': QualityFlags.OK,
-             'global_quality_flag_exp': QualityFlags.INVALID_TIMESTAMP},
-            {'platform': 'NOAA-16',
-             'start_time': np.datetime64('2009-07-01 04:50'),
-             'end_time': np.datetime64('2009-07-01 05:59'),
-             'along_track': 12000,
-             'filename': 'file12',
-             'midnight_scanline': 1234,
-             'overlap_free_start': np.nan,
-             'overlap_free_start_exp': np.nan,
-             'overlap_free_end': np.nan,
-             'overlap_free_end_exp': np.nan,
-             'global_quality_flag': QualityFlags.OK,
-             'global_quality_flag_exp': QualityFlags.REDUNDANT},
-            {'platform': 'NOAA-16',
-             'start_time': np.datetime64('2009-07-01 04:50'),
-             'end_time': np.datetime64('2009-07-01 06:00'),
-             'along_track': 12000,
-             'filename': 'file11',
-             'midnight_scanline': 1234,
-             'overlap_free_start': np.nan,
-             'overlap_free_start_exp': 0,
-             'overlap_free_end': np.nan,
-             'overlap_free_end_exp': 11999,
-             'global_quality_flag': QualityFlags.OK,
-             'global_quality_flag_exp': QualityFlags.OK}
+            {
+                "platform": "NOAA-16",
+                "start_time": np.datetime64("2020-01-01 12:00"),
+                "end_time": np.datetime64("2020-01-01 13:00"),
+                "along_track": 12000,
+                "filename": "file1",
+                "midnight_scanline": 1234,
+                "overlap_free_start": np.nan,
+                "overlap_free_start_exp": np.nan,
+                "overlap_free_end": np.nan,
+                "overlap_free_end_exp": np.nan,
+                "global_quality_flag": QualityFlags.OK,
+                "global_quality_flag_exp": QualityFlags.INVALID_TIMESTAMP,
+            },
+            {
+                "platform": "NOAA-16",
+                "start_time": np.datetime64("2009-06-30"),
+                "end_time": np.datetime64("2049-01-01"),
+                "along_track": 12000,
+                "filename": "file2",
+                "midnight_scanline": 1234,
+                "overlap_free_start": np.nan,
+                "overlap_free_start_exp": np.nan,
+                "overlap_free_end": np.nan,
+                "overlap_free_end_exp": np.nan,
+                "global_quality_flag": QualityFlags.OK,
+                "global_quality_flag_exp": QualityFlags.TOO_LONG,
+            },
+            {
+                "platform": "NOAA-16",
+                "start_time": np.datetime64("2009-07-01 00:00"),
+                "end_time": np.datetime64("2009-07-01 01:00"),
+                "along_track": 12000,
+                "filename": "file3",
+                "midnight_scanline": 1234,
+                "overlap_free_start": np.nan,
+                "overlap_free_start_exp": 0,
+                "overlap_free_end": np.nan,
+                "overlap_free_end_exp": 2,
+                "global_quality_flag": QualityFlags.OK,
+                "global_quality_flag_exp": QualityFlags.OK,
+            },
+            {
+                "platform": "NOAA-16",
+                "start_time": np.datetime64("2009-07-01 00:50"),
+                "end_time": np.datetime64("2009-07-01 02:00"),
+                "along_track": 12000,
+                "filename": "file4",
+                "midnight_scanline": 1234,
+                "overlap_free_start": np.nan,
+                "overlap_free_start_exp": 2,
+                "overlap_free_end": np.nan,
+                "overlap_free_end_exp": 3,
+                "global_quality_flag": QualityFlags.OK,
+                "global_quality_flag_exp": QualityFlags.OK,
+            },
+            {
+                "platform": "NOAA-16",
+                "start_time": np.datetime64("2009-07-01 01:50"),
+                "end_time": np.datetime64("2009-07-01 03:00"),
+                "along_track": 12000,
+                "filename": "file5",
+                "midnight_scanline": 1234,
+                "overlap_free_start": np.nan,
+                "overlap_free_start_exp": 1,
+                "overlap_free_end": np.nan,
+                "overlap_free_end_exp": 2,
+                "global_quality_flag": QualityFlags.OK,
+                "global_quality_flag_exp": QualityFlags.OK,
+            },
+            {
+                "platform": "NOAA-16",
+                "start_time": np.datetime64("2009-07-01 02:15"),
+                "end_time": np.datetime64("2009-07-01 02:30"),
+                "along_track": 12000,
+                "filename": "file6",
+                "midnight_scanline": 1234,
+                "overlap_free_start": np.nan,
+                "overlap_free_start_exp": np.nan,
+                "overlap_free_end": np.nan,
+                "overlap_free_end_exp": np.nan,
+                "global_quality_flag": QualityFlags.OK,
+                "global_quality_flag_exp": QualityFlags.REDUNDANT,
+            },
+            {
+                "platform": "NOAA-16",
+                "start_time": np.datetime64("2009-07-01 02:15"),
+                "end_time": np.datetime64("2009-07-01 02:30"),
+                "along_track": 12000,
+                "filename": "file7",
+                "midnight_scanline": 1234,
+                "overlap_free_start": np.nan,
+                "overlap_free_start_exp": np.nan,
+                "overlap_free_end": np.nan,
+                "overlap_free_end_exp": np.nan,
+                "global_quality_flag": QualityFlags.OK,
+                "global_quality_flag_exp": QualityFlags.DUPLICATE,
+            },
+            {
+                "platform": "NOAA-16",
+                "start_time": np.datetime64("2009-07-01 03:00"),
+                "end_time": np.datetime64("2009-07-01 03:01"),
+                "along_track": 49,
+                "filename": "file8",
+                "midnight_scanline": 1234,
+                "overlap_free_start": np.nan,
+                "overlap_free_start_exp": np.nan,
+                "overlap_free_end": np.nan,
+                "overlap_free_end_exp": np.nan,
+                "global_quality_flag": QualityFlags.OK,
+                "global_quality_flag_exp": QualityFlags.TOO_SHORT,
+            },
+            {
+                "platform": "NOAA-16",
+                "start_time": np.datetime64("2009-07-01 02:50"),
+                "end_time": np.datetime64("2009-07-01 04:00"),
+                "along_track": 12000,
+                "filename": "file9",
+                "midnight_scanline": 1234,
+                "overlap_free_start": np.nan,
+                "overlap_free_start_exp": 2,
+                "overlap_free_end": np.nan,
+                "overlap_free_end_exp": 11999,
+                "global_quality_flag": QualityFlags.OK,
+                "global_quality_flag_exp": QualityFlags.OK,
+            },
+            {
+                "platform": "NOAA-16",
+                "start_time": np.datetime64("2009-07-01 03:50"),
+                "end_time": np.datetime64("2008-07-01 05:00"),
+                "along_track": 12000,
+                "filename": "file10",
+                "midnight_scanline": 1234,
+                "overlap_free_start": np.nan,
+                "overlap_free_start_exp": np.nan,
+                "overlap_free_end": np.nan,
+                "overlap_free_end_exp": np.nan,
+                "global_quality_flag": QualityFlags.OK,
+                "global_quality_flag_exp": QualityFlags.INVALID_TIMESTAMP,
+            },
+            {
+                "platform": "NOAA-16",
+                "start_time": np.datetime64("2009-07-01 04:50"),
+                "end_time": np.datetime64("2009-07-01 05:59"),
+                "along_track": 12000,
+                "filename": "file12",
+                "midnight_scanline": 1234,
+                "overlap_free_start": np.nan,
+                "overlap_free_start_exp": np.nan,
+                "overlap_free_end": np.nan,
+                "overlap_free_end_exp": np.nan,
+                "global_quality_flag": QualityFlags.OK,
+                "global_quality_flag_exp": QualityFlags.REDUNDANT,
+            },
+            {
+                "platform": "NOAA-16",
+                "start_time": np.datetime64("2009-07-01 04:50"),
+                "end_time": np.datetime64("2009-07-01 06:00"),
+                "along_track": 12000,
+                "filename": "file11",
+                "midnight_scanline": 1234,
+                "overlap_free_start": np.nan,
+                "overlap_free_start_exp": 0,
+                "overlap_free_end": np.nan,
+                "overlap_free_end_exp": 11999,
+                "global_quality_flag": QualityFlags.OK,
+                "global_quality_flag_exp": QualityFlags.OK,
+            },
         ]
 
         # Add exact copy with another platform
         if multi_platform:
             noaa17 = [rec.copy() for rec in mda]
             for rec in noaa17:
-                rec['platform'] = 'NOAA-17'
+                rec["platform"] = "NOAA-17"
             mda = mda + noaa17
 
         return pd.DataFrame(mda)
@@ -215,66 +248,85 @@ class MetadataCollectorTest(unittest.TestCase):
     def test_set_global_qual_flags(self):
         mda = self.get_mda(multi_platform=False)
         collector = MetadataCollector()
-        mda_qc = collector._set_global_qual_flags(mda, platform='NOAA-16')
-        pd.testing.assert_series_equal(mda_qc['global_quality_flag'],
-                                       mda_qc['global_quality_flag_exp'],
-                                       check_names=False)
+        mda_qc = collector._set_global_qual_flags(mda, platform="NOAA-16")
+        pd.testing.assert_series_equal(
+            mda_qc["global_quality_flag"],
+            mda_qc["global_quality_flag_exp"],
+            check_names=False,
+        )
 
-    @mock.patch('pygac_fdr.metadata.xr.open_dataset')
+    @mock.patch("pygac_fdr.metadata.xr.open_dataset")
     def test_calc_overlap(self, open_dataset):
         open_dataset.side_effect = open_dataset_patched
 
         # Get test data and set quality flags as they affect the overlap computation
         mda = self.get_mda(multi_platform=False)
-        mda.loc[:, 'global_quality_flag'] = mda['global_quality_flag_exp']
+        mda.loc[:, "global_quality_flag"] = mda["global_quality_flag_exp"]
 
         # Check overlap computation (closed end)
         collector = MetadataCollector()
         mda_overlap = collector._calc_overlap(mda.copy())
-        pd.testing.assert_series_equal(mda_overlap['overlap_free_start'],
-                                       mda_overlap['overlap_free_start_exp'],
-                                       check_names=False)
-        pd.testing.assert_series_equal(mda_overlap['overlap_free_end'],
-                                       mda_overlap['overlap_free_end_exp'],
-                                       check_names=False)
+        pd.testing.assert_series_equal(
+            mda_overlap["overlap_free_start"],
+            mda_overlap["overlap_free_start_exp"],
+            check_names=False,
+        )
+        pd.testing.assert_series_equal(
+            mda_overlap["overlap_free_end"],
+            mda_overlap["overlap_free_end_exp"],
+            check_names=False,
+        )
 
         # Open end
         mda_overlap_open_end = collector._calc_overlap(mda.copy(), open_end=True)
-        np.testing.assert_equal(mda_overlap_open_end.iloc[-1]['overlap_free_end'], np.nan)
+        np.testing.assert_equal(
+            mda_overlap_open_end.iloc[-1]["overlap_free_end"], np.nan
+        )
 
-    @mock.patch('pygac_fdr.metadata.xr.open_dataset')
-    @mock.patch('pygac_fdr.metadata.MetadataCollector._collect_metadata')
+    @mock.patch("pygac_fdr.metadata.xr.open_dataset")
+    @mock.patch("pygac_fdr.metadata.MetadataCollector._collect_metadata")
     def test_get_metadata(self, _collect_metadata, open_dataset):
         _collect_metadata.return_value = self.get_mda(multi_platform=True).sort_values(
-            by=['start_time', 'end_time'], ascending=False)
+            by=["start_time", "end_time"], ascending=False
+        )
         open_dataset.side_effect = open_dataset_patched
 
         collector = MetadataCollector()
-        mda = collector.get_metadata('my_filenames')
+        mda = collector.get_metadata("my_filenames")
 
-        pd.testing.assert_series_equal(mda['global_quality_flag'],
-                                       mda['global_quality_flag_exp'],
-                                       check_names=False)
-        pd.testing.assert_series_equal(mda['overlap_free_start'],
-                                       mda['overlap_free_start_exp'],
-                                       check_names=False)
-        pd.testing.assert_series_equal(mda['overlap_free_end'],
-                                       mda['overlap_free_end_exp'],
-                                       check_names=False)
+        pd.testing.assert_series_equal(
+            mda["global_quality_flag"],
+            mda["global_quality_flag_exp"],
+            check_names=False,
+        )
+        pd.testing.assert_series_equal(
+            mda["overlap_free_start"], mda["overlap_free_start_exp"], check_names=False
+        )
+        pd.testing.assert_series_equal(
+            mda["overlap_free_end"], mda["overlap_free_end_exp"], check_names=False
+        )
 
     def test_get_midnight_line(self):
-        acq_time = xr.DataArray([np.datetime64('2009-12-31 23:58:00'),
-                                 np.datetime64('2009-12-31 23:59:00'),
-                                 np.datetime64('2010-01-01 00:00:01'),
-                                 np.datetime64('2010-01-01 00:01:00')])
+        acq_time = xr.DataArray(
+            [
+                np.datetime64("2009-12-31 23:58:00"),
+                np.datetime64("2009-12-31 23:59:00"),
+                np.datetime64("2010-01-01 00:00:01"),
+                np.datetime64("2010-01-01 00:01:00"),
+            ]
+        )
         collector = MetadataCollector()
         midn_line = collector._get_midnight_line(acq_time)
         self.assertEqual(midn_line, 1)
 
         # No date switch
-        acq_time = xr.DataArray([np.datetime64('2010-01-01 00:00:01'),
-                                 np.datetime64('2010-01-01 00:01:00'),
-                                 np.datetime64('2010-01-01 00:02:00')])
+        acq_time = xr.DataArray(
+            [
+                np.datetime64("2010-01-01 00:00:01"),
+                np.datetime64("2010-01-01 00:01:00"),
+                np.datetime64("2010-01-01 00:02:00"),
+            ]
+        )
         np.testing.assert_equal(collector._get_midnight_line(acq_time), np.nan)
 
     def test_get_equator_crossings(self):
@@ -282,13 +334,17 @@ class MetadataCollectorTest(unittest.TestCase):
 
         # No equator crossing
         ds = xr.Dataset(
-            coords={'latitude': (('y', 'x'), [[999, 5.0, 999],
-                                              [999, 0.1, 999],
-                                              [999, -5.0, 999]]),
-                    'longitude': (('y', 'x'), [[999, 1.0, 999],
-                                               [999, 2.0, 999],
-                                               [999, 3.0, 999]]),
-                    'acq_time': ('y', np.arange(3).astype('datetime64[s]'))}
+            coords={
+                "latitude": (
+                    ("y", "x"),
+                    [[999, 5.0, 999], [999, 0.1, 999], [999, -5.0, 999]],
+                ),
+                "longitude": (
+                    ("y", "x"),
+                    [[999, 1.0, 999], [999, 2.0, 999], [999, 3.0, 999]],
+                ),
+                "acq_time": ("y", np.arange(3).astype("datetime64[s]")),
+            }
         )
         lons, times = collector._get_equator_crossings(ds)
         np.testing.assert_equal(lons, [np.nan, np.nan])
@@ -296,43 +352,73 @@ class MetadataCollectorTest(unittest.TestCase):
 
         # One equator crossing
         ds = xr.Dataset(
-            coords={'latitude': (('y', 'x'), [[999, 5.0, 999],
-                                              [999, 0.1, 999],
-                                              [999, -5.0, 999],
-                                              [999, 0.1, 999],
-                                              [999, 5.0, 999]]),
-                    'longitude': (('y', 'x'), [[999, 1.0, 999],
-                                               [999, 2.0, 999],
-                                               [999, 3.0, 999],
-                                               [999, 4.0, 999],
-                                               [999, 5.0, 999]]),
-                    'acq_time': ('y', np.arange(5).astype('datetime64[s]'))}
+            coords={
+                "latitude": (
+                    ("y", "x"),
+                    [
+                        [999, 5.0, 999],
+                        [999, 0.1, 999],
+                        [999, -5.0, 999],
+                        [999, 0.1, 999],
+                        [999, 5.0, 999],
+                    ],
+                ),
+                "longitude": (
+                    ("y", "x"),
+                    [
+                        [999, 1.0, 999],
+                        [999, 2.0, 999],
+                        [999, 3.0, 999],
+                        [999, 4.0, 999],
+                        [999, 5.0, 999],
+                    ],
+                ),
+                "acq_time": ("y", np.arange(5).astype("datetime64[s]")),
+            }
         )
-        ds['acq_time'].attrs['coords'] = 'latitude longitude'
+        ds["acq_time"].attrs["coords"] = "latitude longitude"
         lons, times = collector._get_equator_crossings(ds)
         np.testing.assert_equal(lons, [3, np.nan])
-        np.testing.assert_equal(times, [np.datetime64('1970-01-01 00:00:02'),
-                                        np.datetime64('NaT')])
+        np.testing.assert_equal(
+            times, [np.datetime64("1970-01-01 00:00:02"), np.datetime64("NaT")]
+        )
 
         # More than two equator crossings
         ds = xr.Dataset(
-            coords={'latitude': (('y', 'x'), [[999, -1, 999],
-                                              [999, 1, 999],
-                                              [999, -1, 999],
-                                              [999, 1, 999],
-                                              [999, -1, 999],
-                                              [999, 1, 999]]),
-                    'longitude': (('y', 'x'), [[999, 1.0, 999],
-                                               [999, 2.0, 999],
-                                               [999, 3.0, 999],
-                                               [999, 4.0, 999],
-                                               [999, 5.0, 999],
-                                               [999, 6.0, 999]]),
-                    'acq_time': ('y', np.arange(6).astype('datetime64[s]'))}
+            coords={
+                "latitude": (
+                    ("y", "x"),
+                    [
+                        [999, -1, 999],
+                        [999, 1, 999],
+                        [999, -1, 999],
+                        [999, 1, 999],
+                        [999, -1, 999],
+                        [999, 1, 999],
+                    ],
+                ),
+                "longitude": (
+                    ("y", "x"),
+                    [
+                        [999, 1.0, 999],
+                        [999, 2.0, 999],
+                        [999, 3.0, 999],
+                        [999, 4.0, 999],
+                        [999, 5.0, 999],
+                        [999, 6.0, 999],
+                    ],
+                ),
+                "acq_time": ("y", np.arange(6).astype("datetime64[s]")),
+            }
         )
-        ds['acq_time'].attrs['coords'] = 'latitude longitude'
+        ds["acq_time"].attrs["coords"] = "latitude longitude"
         collector = MetadataCollector()
         lons, times = collector._get_equator_crossings(ds)
         np.testing.assert_equal(lons, [1, 3])
-        np.testing.assert_equal(times, [np.datetime64('1970-01-01 00:00:00'),
-                                        np.datetime64('1970-01-01 00:00:02')])
+        np.testing.assert_equal(
+            times,
+            [
+                np.datetime64("1970-01-01 00:00:00"),
+                np.datetime64("1970-01-01 00:00:02"),
+            ],
+        )

--- a/pygac_fdr/tests/test_writer.py
+++ b/pygac_fdr/tests/test_writer.py
@@ -16,9 +16,11 @@
 # You should have received a copy of the GNU General Public License along with
 # pygac-fdr. If not, see <http://www.gnu.org/licenses/>.
 
-import numpy as np
 import unittest
-from pygac_fdr.writer import NetcdfWriter, DEFAULT_ENCODING
+
+import numpy as np
+
+from pygac_fdr.writer import DEFAULT_ENCODING, NetcdfWriter
 
 
 class NetcdfWriterTest(unittest.TestCase):

--- a/pygac_fdr/tests/test_writer.py
+++ b/pygac_fdr/tests/test_writer.py
@@ -26,26 +26,27 @@ from pygac_fdr.writer import DEFAULT_ENCODING, NetcdfWriter
 class NetcdfWriterTest(unittest.TestCase):
     def test_get_integer_version(self):
         writer = NetcdfWriter()
-        self.assertEqual(writer._get_integer_version('1.2'), 120)
-        self.assertEqual(writer._get_integer_version('1.2.3'), 123)
-        self.assertEqual(writer._get_integer_version('12.3.4'), 1234)
-        self.assertRaises(ValueError, writer._get_integer_version, '1.10.1')
+        self.assertEqual(writer._get_integer_version("1.2"), 120)
+        self.assertEqual(writer._get_integer_version("1.2.3"), 123)
+        self.assertEqual(writer._get_integer_version("12.3.4"), 1234)
+        self.assertRaises(ValueError, writer._get_integer_version, "1.10.1")
 
     def test_default_encoding(self):
-        bt_range = np.arange(170, 330, 1, dtype='f8')
-        refl_range = np.arange(0, 1.5, 0.1, dtype='f8')
+        bt_range = np.arange(170, 330, 1, dtype="f8")
+        refl_range = np.arange(0, 1.5, 0.1, dtype="f8")
         test_data = {
-            'reflectance_channel_1': refl_range,
-            'reflectance_channel_2': refl_range,
-            'brightness_temperature_channel_3': bt_range,
-            'reflectance_channel_3a': refl_range,
-            'brightness_temperature_channel_3b': bt_range,
-            'brightness_temperature_channel_4': bt_range,
-            'brightness_temperature_channel_5': bt_range
+            "reflectance_channel_1": refl_range,
+            "reflectance_channel_2": refl_range,
+            "brightness_temperature_channel_3": bt_range,
+            "reflectance_channel_3a": refl_range,
+            "brightness_temperature_channel_3b": bt_range,
+            "brightness_temperature_channel_4": bt_range,
+            "brightness_temperature_channel_5": bt_range,
         }
         for ch, data in test_data.items():
             enc = DEFAULT_ENCODING[ch]
-            data_enc = ((data - enc['add_offset']) / enc['scale_factor']).astype(
-                enc['dtype'])
-            data_dec = data_enc * enc['scale_factor'] + enc['add_offset']
+            data_enc = ((data - enc["add_offset"]) / enc["scale_factor"]).astype(
+                enc["dtype"]
+            )
+            data_dec = data_enc * enc["scale_factor"] + enc["add_offset"]
             np.testing.assert_allclose(data_dec, data, rtol=0.1)

--- a/pygac_fdr/utils.py
+++ b/pygac_fdr/utils.py
@@ -35,12 +35,15 @@ def logging_on(level=logging.WARNING, for_all=False):
     """
     global _is_logging_on
     satpy.utils.logging_off()
-    logger_name = '' if for_all else LOGGER_NAME
+    logger_name = "" if for_all else LOGGER_NAME
     if not _is_logging_on:
         console = logging.StreamHandler()
-        console.setFormatter(logging.Formatter("[%(levelname)s: %(asctime)s :"
-                                               " %(name)s] %(message)s",
-                                               '%Y-%m-%d %H:%M:%S'))
+        console.setFormatter(
+            logging.Formatter(
+                "[%(levelname)s: %(asctime)s :" " %(name)s] %(message)s",
+                "%Y-%m-%d %H:%M:%S",
+            )
+        )
         console.setLevel(level)
         logging.getLogger(logger_name).addHandler(console)
         _is_logging_on = True
@@ -57,5 +60,5 @@ def logging_off(for_all=False):
     Args:
         for_all: If True, turn off logging for all modules (default is this package only).
     """
-    logger_name = '' if for_all else LOGGER_NAME
+    logger_name = "" if for_all else LOGGER_NAME
     logging.getLogger(logger_name).handlers = [logging.NullHandler()]

--- a/pygac_fdr/utils.py
+++ b/pygac_fdr/utils.py
@@ -19,6 +19,7 @@
 """Miscellaneous utilities."""
 
 import logging
+
 import satpy.utils
 
 _is_logging_on = False

--- a/pygac_fdr/writer.py
+++ b/pygac_fdr/writer.py
@@ -18,21 +18,22 @@
 
 """Write AVHRR GAC level 1c data to netCDF."""
 
+import logging
+import os
+import warnings
 from datetime import datetime
 from distutils.version import StrictVersion
-import logging
+from string import Formatter
+
 import netCDF4
 import numpy as np
-import os
-import satpy
-from string import Formatter
-import warnings
-import xarray as xr
 import pygac
-import pygac_fdr
-from pygac_fdr.utils import LOGGER_NAME
-from pygac_fdr.metadata import TIME_COVERAGE
+import satpy
+import xarray as xr
 
+import pygac_fdr
+from pygac_fdr.metadata import TIME_COVERAGE
+from pygac_fdr.utils import LOGGER_NAME
 
 LOG = logging.getLogger(LOGGER_NAME)
 

--- a/pygac_fdr/writer.py
+++ b/pygac_fdr/writer.py
@@ -38,125 +38,157 @@ from pygac_fdr.utils import LOGGER_NAME
 LOG = logging.getLogger(LOGGER_NAME)
 
 DATASET_NAMES = {
-    '1': 'reflectance_channel_1',
-    '2': 'reflectance_channel_2',
-    '3': 'brightness_temperature_channel_3',
-    '3a': 'reflectance_channel_3a',
-    '3b': 'brightness_temperature_channel_3b',
-    '4': 'brightness_temperature_channel_4',
-    '5': 'brightness_temperature_channel_5',
+    "1": "reflectance_channel_1",
+    "2": "reflectance_channel_2",
+    "3": "brightness_temperature_channel_3",
+    "3a": "reflectance_channel_3a",
+    "3b": "brightness_temperature_channel_3b",
+    "4": "brightness_temperature_channel_4",
+    "5": "brightness_temperature_channel_5",
 }
 FILL_VALUE_INT16 = -32767
 FILL_VALUE_INT32 = -2147483648
 DEFAULT_ENCODING = {
-    'y': {'dtype': 'int16'},
-    'x': {'dtype': 'int16'},
-    'acq_time': {'units': 'seconds since 1970-01-01 00:00:00',
-                 'calendar': 'standard',
-                 '_FillValue': None},
-    'reflectance_channel_1': {'dtype': 'int16',
-                              'scale_factor': 0.01,
-                              'add_offset': 0,
-                              '_FillValue': FILL_VALUE_INT16,
-                              'zlib': True,
-                              'complevel': 4},
-    'reflectance_channel_2': {'dtype': 'int16',
-                              'scale_factor': 0.01,
-                              'add_offset': 0,
-                              '_FillValue': FILL_VALUE_INT16,
-                              'zlib': True,
-                              'complevel': 4},
-    'brightness_temperature_channel_3': {'dtype': 'int16',
-                                         'scale_factor': 0.01,
-                                         'add_offset': 273.15,
-                                         '_FillValue': FILL_VALUE_INT16,
-                                         'zlib': True,
-                                         'complevel': 4},
-    'reflectance_channel_3a': {'dtype': 'int16',
-                               'scale_factor': 0.01,
-                               'add_offset': 0,
-                               '_FillValue': FILL_VALUE_INT16,
-                               'zlib': True,
-                               'complevel': 4},
-    'brightness_temperature_channel_3b': {'dtype': 'int16',
-                                          'scale_factor': 0.01,
-                                          'add_offset': 273.15,
-                                          '_FillValue': FILL_VALUE_INT16,
-                                          'zlib': True,
-                                          'complevel': 4},
-    'brightness_temperature_channel_4': {'dtype': 'int16',
-                                         'scale_factor': 0.01,
-                                         'add_offset': 273.15,
-                                         '_FillValue': FILL_VALUE_INT16,
-                                         'zlib': True,
-                                         'complevel': 4},
-    'brightness_temperature_channel_5': {'dtype': 'int16',
-                                         'scale_factor': 0.01,
-                                         'add_offset': 273.15,
-                                         '_FillValue': FILL_VALUE_INT16,
-                                         'zlib': True,
-                                         'complevel': 4},
-    'latitude': {'dtype': 'int32',
-                 'scale_factor': 0.001,
-                 'add_offset': 0,
-                 '_FillValue': FILL_VALUE_INT32,
-                 'zlib': True,
-                 'complevel': 4},
-    'longitude': {'dtype': 'int32',
-                  'scale_factor': 0.001,
-                  'add_offset': 0,
-                  '_FillValue': FILL_VALUE_INT32,
-                  'zlib': True,
-                  'complevel': 4},
-    'sensor_azimuth_angle': {'dtype': 'int16',
-                             'scale_factor': 0.01,
-                             'add_offset': 0.0,
-                             '_FillValue': FILL_VALUE_INT16,
-                             'zlib': True,
-                             'complevel': 4},
-    'sensor_zenith_angle': {'dtype': 'int16',
-                            'scale_factor': 0.01,
-                            'add_offset': 0,
-                            '_FillValue': FILL_VALUE_INT16,
-                            'zlib': True,
-                            'complevel': 4},
-    'solar_azimuth_angle': {'dtype': 'int16',
-                            'scale_factor': 0.01,
-                            'add_offset': 0.0,
-                            '_FillValue': FILL_VALUE_INT16,
-                            'zlib': True,
-                            'complevel': 4},
-    'solar_zenith_angle': {'dtype': 'int16',
-                           'scale_factor': 0.01,
-                           'add_offset': 0,
-                           '_FillValue': FILL_VALUE_INT16,
-                           'zlib': True,
-                           'complevel': 4},
-    'sun_sensor_azimuth_difference_angle': {'dtype': 'int16',
-                                            'scale_factor': 0.01,
-                                            'add_offset': 0,
-                                            '_FillValue': FILL_VALUE_INT16,
-                                            'zlib': True,
-                                            'complevel': 4},
-    'qual_flags': {'dtype': 'int16',
-                   '_FillValue': FILL_VALUE_INT16,
-                   'zlib': True,
-                   'complevel': 4},
-    'num_flags': {'dtype': '<S50'}
+    "y": {"dtype": "int16"},
+    "x": {"dtype": "int16"},
+    "acq_time": {
+        "units": "seconds since 1970-01-01 00:00:00",
+        "calendar": "standard",
+        "_FillValue": None,
+    },
+    "reflectance_channel_1": {
+        "dtype": "int16",
+        "scale_factor": 0.01,
+        "add_offset": 0,
+        "_FillValue": FILL_VALUE_INT16,
+        "zlib": True,
+        "complevel": 4,
+    },
+    "reflectance_channel_2": {
+        "dtype": "int16",
+        "scale_factor": 0.01,
+        "add_offset": 0,
+        "_FillValue": FILL_VALUE_INT16,
+        "zlib": True,
+        "complevel": 4,
+    },
+    "brightness_temperature_channel_3": {
+        "dtype": "int16",
+        "scale_factor": 0.01,
+        "add_offset": 273.15,
+        "_FillValue": FILL_VALUE_INT16,
+        "zlib": True,
+        "complevel": 4,
+    },
+    "reflectance_channel_3a": {
+        "dtype": "int16",
+        "scale_factor": 0.01,
+        "add_offset": 0,
+        "_FillValue": FILL_VALUE_INT16,
+        "zlib": True,
+        "complevel": 4,
+    },
+    "brightness_temperature_channel_3b": {
+        "dtype": "int16",
+        "scale_factor": 0.01,
+        "add_offset": 273.15,
+        "_FillValue": FILL_VALUE_INT16,
+        "zlib": True,
+        "complevel": 4,
+    },
+    "brightness_temperature_channel_4": {
+        "dtype": "int16",
+        "scale_factor": 0.01,
+        "add_offset": 273.15,
+        "_FillValue": FILL_VALUE_INT16,
+        "zlib": True,
+        "complevel": 4,
+    },
+    "brightness_temperature_channel_5": {
+        "dtype": "int16",
+        "scale_factor": 0.01,
+        "add_offset": 273.15,
+        "_FillValue": FILL_VALUE_INT16,
+        "zlib": True,
+        "complevel": 4,
+    },
+    "latitude": {
+        "dtype": "int32",
+        "scale_factor": 0.001,
+        "add_offset": 0,
+        "_FillValue": FILL_VALUE_INT32,
+        "zlib": True,
+        "complevel": 4,
+    },
+    "longitude": {
+        "dtype": "int32",
+        "scale_factor": 0.001,
+        "add_offset": 0,
+        "_FillValue": FILL_VALUE_INT32,
+        "zlib": True,
+        "complevel": 4,
+    },
+    "sensor_azimuth_angle": {
+        "dtype": "int16",
+        "scale_factor": 0.01,
+        "add_offset": 0.0,
+        "_FillValue": FILL_VALUE_INT16,
+        "zlib": True,
+        "complevel": 4,
+    },
+    "sensor_zenith_angle": {
+        "dtype": "int16",
+        "scale_factor": 0.01,
+        "add_offset": 0,
+        "_FillValue": FILL_VALUE_INT16,
+        "zlib": True,
+        "complevel": 4,
+    },
+    "solar_azimuth_angle": {
+        "dtype": "int16",
+        "scale_factor": 0.01,
+        "add_offset": 0.0,
+        "_FillValue": FILL_VALUE_INT16,
+        "zlib": True,
+        "complevel": 4,
+    },
+    "solar_zenith_angle": {
+        "dtype": "int16",
+        "scale_factor": 0.01,
+        "add_offset": 0,
+        "_FillValue": FILL_VALUE_INT16,
+        "zlib": True,
+        "complevel": 4,
+    },
+    "sun_sensor_azimuth_difference_angle": {
+        "dtype": "int16",
+        "scale_factor": 0.01,
+        "add_offset": 0,
+        "_FillValue": FILL_VALUE_INT16,
+        "zlib": True,
+        "complevel": 4,
+    },
+    "qual_flags": {
+        "dtype": "int16",
+        "_FillValue": FILL_VALUE_INT16,
+        "zlib": True,
+        "complevel": 4,
+    },
+    "num_flags": {"dtype": "<S50"},
 }  # refers to renamed datasets
-METOP_PRE_LAUNCH_NUMBERS = {'a': 2, 'b': 1, 'c': 3}
+METOP_PRE_LAUNCH_NUMBERS = {"a": 2, "b": 1, "c": 3}
 
 
 def get_platform_short_name(pygac_name):
     """Get 3 character short name for the given platform."""
-    if pygac_name.startswith('noaa'):
+    if pygac_name.startswith("noaa"):
         nr = int(pygac_name[4:])
-        return 'N{:02d}'.format(nr)
-    elif pygac_name.startswith('metop'):
+        return "N{:02d}".format(nr)
+    elif pygac_name.startswith("metop"):
         nr = METOP_PRE_LAUNCH_NUMBERS[pygac_name[5:]]
-        return 'M{:02d}'.format(nr)
-    elif pygac_name == 'tirosn':
-        return 'TSN'
+        return "M{:02d}".format(nr)
+    elif pygac_name == "tirosn":
+        return "TSN"
 
 
 def get_gcmd_platform_name(pygac_name, with_category=True):
@@ -164,22 +196,24 @@ def get_gcmd_platform_name(pygac_name, with_category=True):
 
     FUTURE: Use a library for this. Tried "pythesint" but installation failed.
     """
-    if pygac_name.startswith('noaa'):
+    if pygac_name.startswith("noaa"):
         nr = pygac_name[4:]
-        gcmd_name = '{}-{}'.format(pygac_name[:4], nr).upper()
-        gcmd_series = 'NOAA POES'
-    elif pygac_name.startswith('metop'):
+        gcmd_name = "{}-{}".format(pygac_name[:4], nr).upper()
+        gcmd_series = "NOAA POES"
+    elif pygac_name.startswith("metop"):
         letter = pygac_name[5:]
-        gcmd_name = '{}-{}'.format(pygac_name[:5], letter).upper()
-        gcmd_series = 'METOP'
-    elif pygac_name == 'tirosn':
-        gcmd_name = 'TIROS-N'
-        gcmd_series = 'TIROS'
+        gcmd_name = "{}-{}".format(pygac_name[:5], letter).upper()
+        gcmd_series = "METOP"
+    elif pygac_name == "tirosn":
+        gcmd_name = "TIROS-N"
+        gcmd_series = "TIROS"
     else:
-        raise ValueError('Invalid platform name: {}'.format(pygac_name))
+        raise ValueError("Invalid platform name: {}".format(pygac_name))
 
     if with_category:
-        gcmd_name = '{} > {} > {}'.format('Earth Observation Satellites', gcmd_series, gcmd_name)
+        gcmd_name = "{} > {} > {}".format(
+            "Earth Observation Satellites", gcmd_series, gcmd_name
+        )
 
     return gcmd_name
 
@@ -189,28 +223,39 @@ def get_gcmd_instrument_name(pygac_name):
 
     FUTURE: Use a library for this. Tried "pythesint" but installation failed.
     """
-    cat = 'Earth Remote Sensing Instruments > Passive Remote Sensing > ' \
-          'Spectrometers/Radiometers > Imaging Spectrometers/Radiometers'
-    return '{} > {}'.format(cat, pygac_name.upper())
+    cat = (
+        "Earth Remote Sensing Instruments > Passive Remote Sensing > "
+        "Spectrometers/Radiometers > Imaging Spectrometers/Radiometers"
+    )
+    return "{} > {}".format(cat, pygac_name.upper())
 
 
 class NetcdfWriter:
     """Write AVHRR GAC scenes to netCDF."""
 
-    dataset_specific_attrs = ['units',
-                              'wavelength',
-                              'calibration',
-                              'long_name',
-                              'standard_name']
-    shared_attrs = ['orbital_parameters']
+    dataset_specific_attrs = [
+        "units",
+        "wavelength",
+        "calibration",
+        "long_name",
+        "standard_name",
+    ]
+    shared_attrs = ["orbital_parameters"]
     """Attributes shared between all datasets and to be included only once"""
 
-    def_fname_fmt = 'avhrr_gac_fdr_{platform}_{start_time}_{end_time}.nc'
-    time_fmt = '%Y%m%dT%H%M%SZ'
-    def_engine = 'netcdf4'
+    def_fname_fmt = "avhrr_gac_fdr_{platform}_{start_time}_{end_time}.nc"
+    time_fmt = "%Y%m%dT%H%M%SZ"
+    def_engine = "netcdf4"
 
-    def __init__(self, global_attrs=None, gac_header_attrs=None, encoding=None, engine=None,
-                 fname_fmt=None, debug=None):
+    def __init__(
+        self,
+        global_attrs=None,
+        gac_header_attrs=None,
+        encoding=None,
+        engine=None,
+        fname_fmt=None,
+        debug=None,
+    ):
         """
         Args:
             debug: If True, use constant creation time in output filenames.
@@ -227,8 +272,8 @@ class NetcdfWriter:
 
     def _get_temp_cov(self, scene):
         """Get temporal coverage of the dataset."""
-        tstart = scene['4']['acq_time'][0]
-        tend = scene['4']['acq_time'][-1]
+        tstart = scene["4"]["acq_time"][0]
+        tend = scene["4"]["acq_time"][-1]
         return tstart.dt, tend.dt
 
     def _get_integer_version(self, version):
@@ -242,9 +287,11 @@ class NetcdfWriter:
         """
         numbers = StrictVersion(version).version
         if numbers[1] > 9 or numbers[2] > 9:
-            raise ValueError('Invalid version number: {}. Minor/patch versions > 9 are not '
-                             'supported'.format(version))
-        return sum(10**i * v for i, v in enumerate(reversed(numbers)))
+            raise ValueError(
+                "Invalid version number: {}. Minor/patch versions > 9 are not "
+                "supported".format(version)
+            )
+        return sum(10 ** i * v for i, v in enumerate(reversed(numbers)))
 
     def _compose_filename(self, scene):
         """Compose output filename."""
@@ -256,21 +303,23 @@ class NetcdfWriter:
         else:
             creation_time = datetime.now()
         start_time, end_time = self._get_temp_cov(scene)
-        platform = get_platform_short_name(scene['4'].attrs['platform_name'])
+        platform = get_platform_short_name(scene["4"].attrs["platform_name"])
         try:
-            version = self.global_attrs['product_version']
+            version = self.global_attrs["product_version"]
         except KeyError:
-            version = '0.0.0'
-            msg = 'No product_version set in global attributes. Falling back to 0.0.0'
+            version = "0.0.0"
+            msg = "No product_version set in global attributes. Falling back to 0.0.0"
             LOG.warning(msg)
             warnings.warn(msg)
         version_int = self._get_integer_version(version)
-        fields = {'start_time': start_time.strftime(self.time_fmt).data,
-                  'end_time': end_time.strftime(self.time_fmt).data,
-                  'platform': platform,
-                  'version': version,
-                  'version_int': version_int,
-                  'creation_time': creation_time.strftime(self.time_fmt)}
+        fields = {
+            "start_time": start_time.strftime(self.time_fmt).data,
+            "end_time": end_time.strftime(self.time_fmt).data,
+            "platform": platform,
+            "version": version,
+            "version_int": version_int,
+            "creation_time": creation_time.strftime(self.time_fmt),
+        }
 
         # Search for additional static fields in global attributes
         for _, field, _, _ in Formatter().parse(self.fname_fmt):
@@ -278,8 +327,11 @@ class NetcdfWriter:
                 try:
                     fields[field] = self.global_attrs[field]
                 except KeyError:
-                    raise KeyError('Cannot find filename component {} in global attributes'.format(
-                        field))
+                    raise KeyError(
+                        "Cannot find filename component {} in global attributes".format(
+                            field
+                        )
+                    )
 
         return self.fname_fmt.format(**fields)
 
@@ -290,39 +342,44 @@ class NetcdfWriter:
 
         # Transfer attributes shared by all channels (using channel 4 here, but could be any
         # channel)
-        ch4 = scene['4']
+        ch4 = scene["4"]
         for attr in self.shared_attrs:
             global_attrs[attr] = ch4.attrs[attr]
 
         # Set some dynamic attributes
         start_time, end_time = self._get_temp_cov(scene)
-        time_cov_start, time_cov_end = TIME_COVERAGE[get_gcmd_platform_name(
-            ch4.attrs['platform_name'], with_category=False)]
-        resol = ch4.attrs['resolution']  # all channels have the same resolution
-        global_attrs.update({
-            'platform': get_gcmd_platform_name(ch4.attrs['platform_name']),
-            'instrument': get_gcmd_instrument_name(ch4.attrs['sensor']),
-            'date_created': datetime.now().isoformat(),
-            'start_time': start_time.strftime(self.time_fmt).data,
-            'end_time': end_time.strftime(self.time_fmt).data,
-            'sun_earth_distance_correction_factor': ch4.attrs['sun_earth_distance_correction_factor'],
-            'version_pygac': pygac.__version__,
-            'version_pygac_fdr': pygac_fdr.__version__,
-            'version_satpy': satpy.__version__,
-            'version_calib_coeffs': ch4.attrs['calib_coeffs_version'],
-            'geospatial_lon_min': scene['longitude'].min().values,
-            'geospatial_lon_max': scene['longitude'].max().values,
-            'geospatial_lon_units': 'degrees_east',
-            'geospatial_lat_min': scene['latitude'].min().values,
-            'geospatial_lat_max': scene['latitude'].max().values,
-            'geospatial_lat_units': 'degrees_north',
-            'geospatial_lon_resolution': '{} meters'.format(resol),
-            'geospatial_lat_resolution': '{} meters'.format(resol),
-            'time_coverage_start': time_cov_start.strftime(self.time_fmt),
-        })
+        time_cov_start, time_cov_end = TIME_COVERAGE[
+            get_gcmd_platform_name(ch4.attrs["platform_name"], with_category=False)
+        ]
+        resol = ch4.attrs["resolution"]  # all channels have the same resolution
+        global_attrs.update(
+            {
+                "platform": get_gcmd_platform_name(ch4.attrs["platform_name"]),
+                "instrument": get_gcmd_instrument_name(ch4.attrs["sensor"]),
+                "date_created": datetime.now().isoformat(),
+                "start_time": start_time.strftime(self.time_fmt).data,
+                "end_time": end_time.strftime(self.time_fmt).data,
+                "sun_earth_distance_correction_factor": ch4.attrs[
+                    "sun_earth_distance_correction_factor"
+                ],
+                "version_pygac": pygac.__version__,
+                "version_pygac_fdr": pygac_fdr.__version__,
+                "version_satpy": satpy.__version__,
+                "version_calib_coeffs": ch4.attrs["calib_coeffs_version"],
+                "geospatial_lon_min": scene["longitude"].min().values,
+                "geospatial_lon_max": scene["longitude"].max().values,
+                "geospatial_lon_units": "degrees_east",
+                "geospatial_lat_min": scene["latitude"].min().values,
+                "geospatial_lat_max": scene["latitude"].max().values,
+                "geospatial_lat_units": "degrees_north",
+                "geospatial_lon_resolution": "{} meters".format(resol),
+                "geospatial_lat_resolution": "{} meters".format(resol),
+                "time_coverage_start": time_cov_start.strftime(self.time_fmt),
+            }
+        )
         if time_cov_end:  # Otherwise still operational
-            global_attrs['time_coverage_end'] = time_cov_end.strftime(self.time_fmt)
-        global_attrs.pop('sensor')  # we already have "instrument"
+            global_attrs["time_coverage_end"] = time_cov_end.strftime(self.time_fmt)
+        global_attrs.pop("sensor")  # we already have "instrument"
 
         # User defined static attributes take precedence over dynamic attributes.
         global_attrs.update(self.global_attrs)
@@ -331,10 +388,15 @@ class NetcdfWriter:
 
     def _cleanup_attrs(self, scene):
         """Cleanup attributes repeated in each dataset of the scene."""
-        keep_attrs = self.dataset_specific_attrs + ['name', 'area']
+        keep_attrs = self.dataset_specific_attrs + ["name", "area"]
         for ds in scene.keys():
-            scene[ds].attrs = dict([(attr, val) for attr, val in scene[ds].attrs.items()
-                                    if attr in keep_attrs])
+            scene[ds].attrs = dict(
+                [
+                    (attr, val)
+                    for attr, val in scene[ds].attrs.items()
+                    if attr in keep_attrs
+                ]
+            )
 
     def _rename_datasets(self, scene):
         """Rename datasets in the scene to more verbose names."""
@@ -347,20 +409,29 @@ class NetcdfWriter:
 
     def _set_custom_attrs(self, scene):
         """Set custom dataset attributes."""
-        scene['qual_flags'].attrs['comment'] = 'Seven binary quality flags are provided per ' \
-                                               'scanline. See the num_flags coordinate for their ' \
-                                               'meanings.'
+        scene["qual_flags"].attrs["comment"] = (
+            "Seven binary quality flags are provided per "
+            "scanline. See the num_flags coordinate for their "
+            "meanings."
+        )
         for ds_name in scene.keys():
-            scene[ds_name]['acq_time'].attrs.update({'standard_name': 'time', 'axis': 'T'})
+            scene[ds_name]["acq_time"].attrs.update(
+                {"standard_name": "time", "axis": "T"}
+            )
 
-            if scene[ds_name].dims == ('y', 'x'):
+            if scene[ds_name].dims == ("y", "x"):
                 scene[ds_name] = scene[ds_name].assign_coords(
-                    {'y': np.arange(scene[ds_name].shape[0]),
-                     'x': np.arange(scene[ds_name].shape[1])})
-                scene[ds_name].coords['x'].attrs.update({'axis': 'X',
-                                                         'long_name': 'Pixel number'})
-                scene[ds_name].coords['y'].attrs.update({'axis': 'Y',
-                                                         'long_name': 'Line number'})
+                    {
+                        "y": np.arange(scene[ds_name].shape[0]),
+                        "x": np.arange(scene[ds_name].shape[1]),
+                    }
+                )
+                scene[ds_name].coords["x"].attrs.update(
+                    {"axis": "X", "long_name": "Pixel number"}
+                )
+                scene[ds_name].coords["y"].attrs.update(
+                    {"axis": "Y", "long_name": "Line number"}
+                )
 
     def _get_encoding(self, scene):
         """Get netCDF encoding for the datasets in the scene."""
@@ -369,15 +440,18 @@ class NetcdfWriter:
         enc_keys = set(self.encoding.keys())
         scn_keys = set([key.name for key in scene.keys()])
         scn_keys = scn_keys.union(
-            set([coord for key in scene.keys() for coord in scene[key].coords]))
-        encoding = dict([(key, self.encoding[key]) for key in enc_keys.intersection(scn_keys)])
+            set([coord for key in scene.keys() for coord in scene[key].coords])
+        )
+        encoding = dict(
+            [(key, self.encoding[key]) for key in enc_keys.intersection(scn_keys)]
+        )
 
         # Make sure scale_factor and add_offset are both double
         for enc in encoding.values():
-            if 'scale_factor' in enc:
-                enc['scale_factor'] = np.float64(enc['scale_factor'])
-            if 'add_offset' in enc:
-                enc['add_offset'] = np.float64(enc['add_offset'])
+            if "scale_factor" in enc:
+                enc["scale_factor"] = np.float64(enc["scale_factor"])
+            if "add_offset" in enc:
+                enc["add_offset"] = np.float64(enc["add_offset"])
 
         return encoding
 
@@ -388,27 +462,27 @@ class NetcdfWriter:
         attributes.
         """
         for ds_name in scene.keys():
-            if scene[ds_name].dims == ('y', 'x'):
-                scene[ds_name].coords['longitude'] = (('y', 'x'), scene['longitude'])
-                scene[ds_name].coords['latitude'] = (('y', 'x'), scene['latitude'])
+            if scene[ds_name].dims == ("y", "x"):
+                scene[ds_name].coords["longitude"] = (("y", "x"), scene["longitude"])
+                scene[ds_name].coords["latitude"] = (("y", "x"), scene["latitude"])
 
     def _fix_global_attrs(self, filename, global_attrs):
-        LOG.info('Fixing global attributes')
-        with netCDF4.Dataset(filename, mode='a') as nc:
+        LOG.info("Fixing global attributes")
+        with netCDF4.Dataset(filename, mode="a") as nc:
             # Satpy's CF writer overrides Conventions attribute
-            nc.Conventions = global_attrs['Conventions']
+            nc.Conventions = global_attrs["Conventions"]
 
             # Satpy's CF writer assumes x/y to be projection coordinates
-            for var_name in ('x', 'y'):
-                for drop_attr in ['standard_name', 'units']:
+            for var_name in ("x", "y"):
+                for drop_attr in ["standard_name", "units"]:
                     nc.variables[var_name].delncattr(drop_attr)
 
     def _append_gac_header(self, filename, header):
         """Append raw GAC header to the given netCDF file."""
-        LOG.info('Appending GAC header')
+        LOG.info("Appending GAC header")
         data_vars = dict([(name, header[name]) for name in header.dtype.names])
         header = xr.Dataset(data_vars, attrs=self.gac_header_attrs)
-        header.to_netcdf(filename, mode='a', group='gac_header')
+        header.to_netcdf(filename, mode="a", group="gac_header")
 
     def write(self, scene, output_dir=None):
         """Write an AVHRR GAC scene to netCDF.
@@ -420,23 +494,25 @@ class NetcdfWriter:
         Returns:
             Names of files written.
         """
-        output_dir = output_dir or '.'
+        output_dir = output_dir or "."
         filename = os.path.join(output_dir, self._compose_filename(scene))
-        gac_header = scene['4'].attrs['gac_header'].copy()
+        gac_header = scene["4"].attrs["gac_header"].copy()
         global_attrs = self._get_global_attrs(scene)
         self._cleanup_attrs(scene)
         self._set_custom_attrs(scene)
         self._rename_datasets(scene)
         self._update_coordinates(scene)
         encoding = self._get_encoding(scene)
-        LOG.info('Writing calibrated scene to {}'.format(filename))
-        scene.save_datasets(writer='cf',
-                            filename=filename,
-                            header_attrs=global_attrs,
-                            engine=self.engine,
-                            flatten_attrs=True,
-                            encoding=encoding,
-                            pretty=True)
+        LOG.info("Writing calibrated scene to {}".format(filename))
+        scene.save_datasets(
+            writer="cf",
+            filename=filename,
+            header_attrs=global_attrs,
+            engine=self.engine,
+            flatten_attrs=True,
+            encoding=encoding,
+            pretty=True,
+        )
         self._append_gac_header(filename, gac_header)
         self._fix_global_attrs(filename, global_attrs)
         return filename

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,2 +1,17 @@
 [flake8]
-max-line-length = 120
+ignore =
+    E203 # whitespace before ':' - doesn't work well with black
+    E402 # module level import not at top of file
+    E501 # line too long - let black worry about that
+    E731 # do not assign a lambda expression, use a def
+    W503 # line break before binary operator
+exclude=
+    .eggs
+    doc
+
+[isort]
+profile = black
+skip_gitignore = true
+force_to_top = true
+default_section = THIRDPARTY
+known_first_party = pygac_fdr

--- a/setup.py
+++ b/setup.py
@@ -17,43 +17,65 @@
 # pygac-fdr. If not, see <http://www.gnu.org/licenses/>.
 
 import os
+
 from setuptools import find_packages, setup
+
 try:
     # HACK: https://github.com/pypa/setuptools_scm/issues/190#issuecomment-351181286
     # Stop setuptools_scm from including all repository files
     import setuptools_scm.integration
+
     setuptools_scm.integration.find_files = lambda _: []
 except ImportError:
     pass
 
 
-if __name__ == '__main__':
-    requires = ['setuptools_scm', 'numpy', 'xarray >=0.15.1', 'pandas >=1.0.3', 'netCDF4',
-                'h5py', 'pygac >=1.3.1', 'satpy >=0.21.0', 'pyyaml', 'trollsift']
+if __name__ == "__main__":
+    requires = [
+        "setuptools_scm",
+        "numpy",
+        "xarray >=0.15.1",
+        "pandas >=1.0.3",
+        "netCDF4",
+        "h5py",
+        "pygac >=1.3.1",
+        "satpy >=0.21.0",
+        "pyyaml",
+        "trollsift",
+    ]
     extras_require = {
-        "tests": ['cfchecker @ git+https://github.com/cedadev/cf-checker#egg=cfchecker',
-                  'pytest', 'pytest-cov', 'pytest-testconfig', 'matplotlib']
+        "tests": [
+            "cfchecker @ git+https://github.com/cedadev/cf-checker#egg=cfchecker",
+            "pytest",
+            "pytest-cov",
+            "pytest-testconfig",
+            "matplotlib",
+        ],
+        "dev": ["pre-commit"],
     }
-    README = open('README.md', 'r').read()
-    setup(name='pygac-fdr',
-          description='Python package for creating a Fundamental Data Record (FDR) of AVHRR GAC '
-                      'data using pygac',
-          long_description=README,
-          long_description_content_type='text/markdown',
-          classifiers=["Development Status :: 3 - Alpha",
-                       "Intended Audience :: Science/Research",
-                       "License :: OSI Approved :: GNU General Public License v3 " +
-                       "or later (GPLv3+)",
-                       "Operating System :: OS Independent",
-                       "Programming Language :: Python",
-                       "Topic :: Scientific/Engineering"],
-          author='The Pytroll Team',
-          author_email='pytroll@googlegroups.com',
-          url="https://github.com/pytroll/pygac-fdr",
-          packages=find_packages(),
-          scripts=[os.path.join('bin', item) for item in os.listdir('bin')],
-          use_scm_version=True,
-          install_requires=requires,
-          extras_require=extras_require,
-          python_requires='>=3.6',
-          )
+    README = open("README.md", "r").read()
+    setup(
+        name="pygac-fdr",
+        description="Python package for creating a Fundamental Data Record (FDR) of AVHRR GAC "
+        "data using pygac",
+        long_description=README,
+        long_description_content_type="text/markdown",
+        classifiers=[
+            "Development Status :: 3 - Alpha",
+            "Intended Audience :: Science/Research",
+            "License :: OSI Approved :: GNU General Public License v3 "
+            + "or later (GPLv3+)",
+            "Operating System :: OS Independent",
+            "Programming Language :: Python",
+            "Topic :: Scientific/Engineering",
+        ],
+        author="The Pytroll Team",
+        author_email="pytroll@googlegroups.com",
+        url="https://github.com/pytroll/pygac-fdr",
+        packages=find_packages(),
+        scripts=[os.path.join("bin", item) for item in os.listdir("bin")],
+        use_scm_version=True,
+        install_requires=requires,
+        extras_require=extras_require,
+        python_requires=">=3.6",
+    )


### PR DESCRIPTION
- Apply `black` code formatting and sort imports using `isort`.
- Add pre-commit hooks for `black`, `isort` and `flake8` (copied from `xarray`).
- Furthermore, remove special characters from config file (`references` attribute). This requires an update of reference data for system tests.