### PR TITLE
Fixing two pygac fdr bugs

### DIFF
--- a/pygac_fdr/writer.py
+++ b/pygac_fdr/writer.py
@@ -464,7 +464,7 @@ class NetcdfWriter:
         for ds_name in scene.keys():
             if scene[ds_name].dims == ("y", "x"):
                 for coord_name in ("latitude", "longitude"):
-                    scene[ds_name].coords[coord_name] = (("y", "x"), scene[coord_name])
+                    scene[ds_name].coords[coord_name] = (("y", "x"), scene[coord_name].data)
                     scene[ds_name].coords[coord_name].attrs = dict(
                         (key, val)
                         for key, val in scene[coord_name].attrs.copy().items()

--- a/pygac_fdr/writer.py
+++ b/pygac_fdr/writer.py
@@ -344,7 +344,10 @@ class NetcdfWriter:
         # channel)
         ch4 = scene["4"]
         for attr in self.shared_attrs:
-            global_attrs[attr] = ch4.attrs[attr]
+            try:
+                global_attrs[attr] = ch4.attrs[attr]
+            except KeyError:
+                pass
 
         # Set some dynamic attributes
         start_time, end_time = self._get_temp_cov(scene)


### PR DESCRIPTION
Two tiny issues:
- If there are no TLE data, there are no orbital parameters to be added to global attributes.
- fixing TypeError by using .data property