### PR TITLE
Fix grouping metadata by platform

### DIFF
--- a/bin/pygac-fdr-mda-collect
+++ b/bin/pygac-fdr-mda-collect
@@ -20,7 +20,11 @@
 import argparse
 import logging
 
-from pygac_fdr.metadata import MetadataCollector
+from pygac_fdr.metadata import (
+    MetadataCollector,
+    MetadataEnhancer,
+    save_metadata_to_database,
+)
 from pygac_fdr.utils import LOGGER_NAME, logging_on
 
 LOG = logging.getLogger(LOGGER_NAME)
@@ -49,5 +53,7 @@ if __name__ == "__main__":
     logging_on(logging.DEBUG if args.verbose else logging.INFO)
 
     collector = MetadataCollector()
-    mda = collector.get_metadata(args.filenames)
-    collector.save_sql(mda, args.dbfile, args.if_exists)
+    mda = collector.collect_metadata(args.filenames)
+    enhancer = MetadataEnhancer()
+    mda = enhancer.enhance_metadata(mda)
+    save_metadata_to_database(mda, args.dbfile, args.if_exists)

--- a/bin/pygac-fdr-mda-update
+++ b/bin/pygac-fdr-mda-update
@@ -19,7 +19,7 @@
 import argparse
 import logging
 
-from pygac_fdr.metadata import MetadataCollector, MetadataUpdater
+from pygac_fdr.metadata import MetadataUpdater, read_metadata_from_database
 from pygac_fdr.utils import logging_on
 
 if __name__ == "__main__":
@@ -34,7 +34,6 @@ if __name__ == "__main__":
     args = parser.parse_args()
     logging_on(logging.DEBUG if args.verbose else logging.INFO)
 
-    collector = MetadataCollector()
-    mda = collector.read_sql(args.dbfile)
+    mda = read_metadata_from_database(args.dbfile)
     updater = MetadataUpdater()
     updater.update(mda)

--- a/pygac_fdr/metadata.py
+++ b/pygac_fdr/metadata.py
@@ -355,7 +355,7 @@ class MetadataEnhancer:
     def _calc_overlap(self, df):
         LOG.info("Computing overlap")
         grouped = df.groupby("platform", as_index=False)
-        return grouped.apply(lambda x: self._calc_overlap_single_platform(x))
+        return grouped.apply(self._calc_overlap_single_platform)
 
     def _calc_overlap_single_platform(self, df, open_end=False):
         """Compare timestamps of neighbouring files and determine overlap.

--- a/pygac_fdr/metadata.py
+++ b/pygac_fdr/metadata.py
@@ -121,61 +121,9 @@ ADDITIONAL_METADATA = [
 
 
 class MetadataCollector:
-    """Collect and complement metadata from level 1c files.
+    """Collect metadata from level 1c files."""
 
-    Additional metadata include global quality flags as well equator crossing time and
-    overlap information.
-    """
-
-    def __init__(self, min_num_lines=50, min_duration=5):
-        """
-        Args:
-            min_num_lines: Minimum number of scanlines for a file to be considered ok. Otherwise
-                           it will flagged as too short.
-            min_duration: Minimum duration (in minutes) for a file to be considered ok. Otherwise
-                          it will flagged as too short.
-        """
-        self.min_num_lines = min_num_lines
-        self.min_duration = np.timedelta64(min_duration, "m")
-
-    def get_metadata(self, filenames):
-        """Collect and complement metadata from the given level 1c files."""
-        LOG.info("Collecting metadata")
-        df = pd.DataFrame(self._collect_metadata(filenames))
-        df.sort_values(by=["start_time", "end_time"], inplace=True)
-
-        # Set quality flags
-        LOG.info("Computing quality flags")
-        df = df.groupby("platform").apply(
-            lambda x: self._set_global_qual_flags(x, x.name)
-        )
-        df = df.drop(["platform"], axis=1)
-
-        # Calculate overlap
-        LOG.info("Computing overlap")
-        df = df.groupby("platform").apply(lambda x: self._calc_overlap(x))
-
-        return df
-
-    def save_sql(self, mda, dbfile, if_exists):
-        """Save metadata to sqlite database."""
-        con = sqlite3.connect(dbfile)
-        mda.to_sql(name="metadata", con=con, if_exists=if_exists)
-        con.commit()
-        con.close()
-
-    def read_sql(self, dbfile):
-        """Read metadata from sqlite database."""
-        with sqlite3.connect(dbfile) as con:
-            mda = pd.read_sql("select * from metadata", con)
-        mda = mda.set_index(["platform", "level_1"])
-        mda.fillna(value=np.nan, inplace=True)
-        for col in mda.columns:
-            if "time" in col:
-                mda[col] = mda[col].astype("datetime64[ns]")
-        return mda
-
-    def _collect_metadata(self, filenames):
+    def collect_metadata(self, filenames):
         """Collect metadata from the given level 1c files."""
         records = []
         for filename in filenames:
@@ -201,7 +149,7 @@ class MetadataCollector:
                     "global_quality_flag": QualityFlags.OK,
                 }
                 records.append(rec)
-        return records
+        return pd.DataFrame(records)
 
     def _get_midnight_line(self, acq_time):
         """Find scanline where the UTC date increases by one day.
@@ -246,6 +194,42 @@ class MetadataCollector:
         eq_cross_lons[0:num_cross] = lat_eq["longitude"].values[0:num_cross]
         eq_cross_times[0:num_cross] = lat_eq["acq_time"].values[0:num_cross]
         return eq_cross_lons, eq_cross_times
+
+
+class MetadataEnhancer:
+    """Enhance metadata of level 1c files.
+
+    Additional metadata include global quality flags as well equator crossing time and
+    overlap information.
+    """
+
+    def __init__(self, min_num_lines=50, min_duration=5):
+        """
+        Args:
+            min_num_lines: Minimum number of scanlines for a file to be considered ok. Otherwise
+                           it will flagged as too short.
+            min_duration: Minimum duration (in minutes) for a file to be considered ok. Otherwise
+                          it will flagged as too short.
+        """
+        self.min_num_lines = min_num_lines
+        self.min_duration = np.timedelta64(min_duration, "m")
+
+    def enhance_metadata(self, df):
+        """Complement metadata from level 1c files."""
+        df.sort_values(by=["start_time", "end_time"], inplace=True)
+
+        # Set quality flags
+        LOG.info("Computing quality flags")
+        df = df.groupby("platform", as_index=True).apply(
+            lambda x: self._set_global_qual_flags(x, x.name)
+        )
+        df = df.drop(["platform"], axis=1)
+
+        # Calculate overlap
+        LOG.info("Computing overlap")
+        df = df.groupby("platform").apply(lambda x: self._calc_overlap(x))
+
+        return df
 
     def _set_redundant_flag(self, df, window=20):
         """Flag redundant files in the given data frame.
@@ -411,6 +395,26 @@ class MetadataCollector:
                 df.loc[df_ok.index[i], "overlap_free_end"] = this_row["along_track"] - 1
 
         return df
+
+
+def save_metadata_to_database(mda, dbfile, if_exists):
+    """Save metadata to sqlite database."""
+    con = sqlite3.connect(dbfile)
+    mda.to_sql(name="metadata", con=con, if_exists=if_exists)
+    con.commit()
+    con.close()
+
+
+def read_metadata_from_database(dbfile):
+    """Read metadata from sqlite database."""
+    with sqlite3.connect(dbfile) as con:
+        mda = pd.read_sql("select * from metadata", con)
+    mda = mda.set_index(["platform", "index"])
+    mda.fillna(value=np.nan, inplace=True)
+    for col in mda.columns:
+        if "time" in col:
+            mda[col] = mda[col].astype("datetime64[ns]")
+    return mda
 
 
 class MetadataUpdater:

--- a/pygac_fdr/tests/test_metadata.py
+++ b/pygac_fdr/tests/test_metadata.py
@@ -16,14 +16,13 @@
 # You should have received a copy of the GNU General Public License along with
 # pygac-fdr. If not, see <http://www.gnu.org/licenses/>.
 
-import unittest
 from unittest import mock
 
 import numpy as np
 import pandas as pd
 import xarray as xr
 
-from pygac_fdr.metadata import MetadataCollector, QualityFlags
+from pygac_fdr.metadata import MetadataCollector, MetadataEnhancer, QualityFlags
 
 
 def open_dataset_patched(filename):
@@ -63,8 +62,127 @@ def open_dataset_patched(filename):
     return times.get(filename, xr.Dataset({"acq_time": [0]}))
 
 
-class MetadataCollectorTest(unittest.TestCase):
-    def get_mda(self, multi_platform=False):
+class TestMetadataCollector:
+    def test_get_midnight_line(self):
+        acq_time = xr.DataArray(
+            [
+                np.datetime64("2009-12-31 23:58:00"),
+                np.datetime64("2009-12-31 23:59:00"),
+                np.datetime64("2010-01-01 00:00:01"),
+                np.datetime64("2010-01-01 00:01:00"),
+            ]
+        )
+        collector = MetadataCollector()
+        midn_line = collector._get_midnight_line(acq_time)
+        assert midn_line == 1
+
+        # No date switch
+        acq_time = xr.DataArray(
+            [
+                np.datetime64("2010-01-01 00:00:01"),
+                np.datetime64("2010-01-01 00:01:00"),
+                np.datetime64("2010-01-01 00:02:00"),
+            ]
+        )
+        np.testing.assert_equal(collector._get_midnight_line(acq_time), np.nan)
+
+    def test_get_equator_crossings(self):
+        collector = MetadataCollector()
+
+        # No equator crossing
+        ds = xr.Dataset(
+            coords={
+                "latitude": (
+                    ("y", "x"),
+                    [[999, 5.0, 999], [999, 0.1, 999], [999, -5.0, 999]],
+                ),
+                "longitude": (
+                    ("y", "x"),
+                    [[999, 1.0, 999], [999, 2.0, 999], [999, 3.0, 999]],
+                ),
+                "acq_time": ("y", np.arange(3).astype("datetime64[s]")),
+            }
+        )
+        lons, times = collector._get_equator_crossings(ds)
+        np.testing.assert_equal(lons, [np.nan, np.nan])
+        assert np.all(np.isnat(times))
+
+        # One equator crossing
+        ds = xr.Dataset(
+            coords={
+                "latitude": (
+                    ("y", "x"),
+                    [
+                        [999, 5.0, 999],
+                        [999, 0.1, 999],
+                        [999, -5.0, 999],
+                        [999, 0.1, 999],
+                        [999, 5.0, 999],
+                    ],
+                ),
+                "longitude": (
+                    ("y", "x"),
+                    [
+                        [999, 1.0, 999],
+                        [999, 2.0, 999],
+                        [999, 3.0, 999],
+                        [999, 4.0, 999],
+                        [999, 5.0, 999],
+                    ],
+                ),
+                "acq_time": ("y", np.arange(5).astype("datetime64[s]")),
+            }
+        )
+        ds["acq_time"].attrs["coords"] = "latitude longitude"
+        lons, times = collector._get_equator_crossings(ds)
+        np.testing.assert_equal(lons, [3, np.nan])
+        np.testing.assert_equal(
+            times, [np.datetime64("1970-01-01 00:00:02"), np.datetime64("NaT")]
+        )
+
+        # More than two equator crossings
+        ds = xr.Dataset(
+            coords={
+                "latitude": (
+                    ("y", "x"),
+                    [
+                        [999, -1, 999],
+                        [999, 1, 999],
+                        [999, -1, 999],
+                        [999, 1, 999],
+                        [999, -1, 999],
+                        [999, 1, 999],
+                    ],
+                ),
+                "longitude": (
+                    ("y", "x"),
+                    [
+                        [999, 1.0, 999],
+                        [999, 2.0, 999],
+                        [999, 3.0, 999],
+                        [999, 4.0, 999],
+                        [999, 5.0, 999],
+                        [999, 6.0, 999],
+                    ],
+                ),
+                "acq_time": ("y", np.arange(6).astype("datetime64[s]")),
+            }
+        )
+        ds["acq_time"].attrs["coords"] = "latitude longitude"
+        collector = MetadataCollector()
+        lons, times = collector._get_equator_crossings(ds)
+        np.testing.assert_equal(lons, [1, 3])
+        np.testing.assert_equal(
+            times,
+            [
+                np.datetime64("1970-01-01 00:00:00"),
+                np.datetime64("1970-01-01 00:00:02"),
+            ],
+        )
+
+
+class TestMetadataEnhancer:
+    def get_mda(self, multi_platform=False, reverse=False):
         mda = [
             {
                 "platform": "NOAA-16",
@@ -243,17 +361,10 @@ class MetadataCollectorTest(unittest.TestCase):
                 rec["platform"] = "NOAA-17"
             mda = mda + noaa17
 
-        return pd.DataFrame(mda)
-
-    def test_set_global_qual_flags(self):
-        mda = self.get_mda(multi_platform=False)
-        collector = MetadataCollector()
-        mda_qc = collector._set_global_qual_flags(mda, platform="NOAA-16")
-        pd.testing.assert_series_equal(
-            mda_qc["global_quality_flag"],
-            mda_qc["global_quality_flag_exp"],
-            check_names=False,
-        )
+        df = pd.DataFrame(mda)
+        if reverse:
+            df = df.sort_values(by=["start_time", "end_time"], ascending=False)
+        return df
 
     @mock.patch("pygac_fdr.metadata.xr.open_dataset")
     def test_calc_overlap(self, open_dataset):
@@ -264,8 +375,8 @@ class MetadataCollectorTest(unittest.TestCase):
         mda.loc[:, "global_quality_flag"] = mda["global_quality_flag_exp"]
 
         # Check overlap computation (closed end)
-        collector = MetadataCollector()
-        mda_overlap = collector._calc_overlap(mda.copy())
+        enhancer = MetadataEnhancer()
+        mda_overlap = enhancer._calc_overlap(mda.copy())
         pd.testing.assert_series_equal(
             mda_overlap["overlap_free_start"],
             mda_overlap["overlap_free_start_exp"],
@@ -278,21 +389,17 @@ class MetadataCollectorTest(unittest.TestCase):
         )
 
         # Open end
-        mda_overlap_open_end = collector._calc_overlap(mda.copy(), open_end=True)
+        mda_overlap_open_end = enhancer._calc_overlap(mda.copy(), open_end=True)
         np.testing.assert_equal(
             mda_overlap_open_end.iloc[-1]["overlap_free_end"], np.nan
         )
 
     @mock.patch("pygac_fdr.metadata.xr.open_dataset")
-    @mock.patch("pygac_fdr.metadata.MetadataCollector._collect_metadata")
-    def test_get_metadata(self, _collect_metadata, open_dataset):
-        _collect_metadata.return_value = self.get_mda(multi_platform=True).sort_values(
-            by=["start_time", "end_time"], ascending=False
-        )
+    def test_enhance_metadata(self, open_dataset):
         open_dataset.side_effect = open_dataset_patched
-
-        collector = MetadataCollector()
-        mda = collector.get_metadata("my_filenames")
+        mda = self.get_mda(multi_platform=True, reverse=True)
+        enhancer = MetadataEnhancer()
+        mda = enhancer.enhance_metadata(mda)
 
         pd.testing.assert_series_equal(
             mda["global_quality_flag"],
@@ -304,121 +411,4 @@ class MetadataCollectorTest(unittest.TestCase):
         )
         pd.testing.assert_series_equal(
             mda["overlap_free_end"], mda["overlap_free_end_exp"], check_names=False
-        )
-
-    def test_get_midnight_line(self):
-        acq_time = xr.DataArray(
-            [
-                np.datetime64("2009-12-31 23:58:00"),
-                np.datetime64("2009-12-31 23:59:00"),
-                np.datetime64("2010-01-01 00:00:01"),
-                np.datetime64("2010-01-01 00:01:00"),
-            ]
-        )
-        collector = MetadataCollector()
-        midn_line = collector._get_midnight_line(acq_time)
-        self.assertEqual(midn_line, 1)
-
-        # No date switch
-        acq_time = xr.DataArray(
-            [
-                np.datetime64("2010-01-01 00:00:01"),
-                np.datetime64("2010-01-01 00:01:00"),
-                np.datetime64("2010-01-01 00:02:00"),
-            ]
-        )
-        np.testing.assert_equal(collector._get_midnight_line(acq_time), np.nan)
-
-    def test_get_equator_crossings(self):
-        collector = MetadataCollector()
-
-        # No equator crossing
-        ds = xr.Dataset(
-            coords={
-                "latitude": (
-                    ("y", "x"),
-                    [[999, 5.0, 999], [999, 0.1, 999], [999, -5.0, 999]],
-                ),
-                "longitude": (
-                    ("y", "x"),
-                    [[999, 1.0, 999], [999, 2.0, 999], [999, 3.0, 999]],
-                ),
-                "acq_time": ("y", np.arange(3).astype("datetime64[s]")),
-            }
-        )
-        lons, times = collector._get_equator_crossings(ds)
-        np.testing.assert_equal(lons, [np.nan, np.nan])
-        self.assertTrue(np.all(np.isnat(times)))
-
-        # One equator crossing
-        ds = xr.Dataset(
-            coords={
-                "latitude": (
-                    ("y", "x"),
-                    [
-                        [999, 5.0, 999],
-                        [999, 0.1, 999],
-                        [999, -5.0, 999],
-                        [999, 0.1, 999],
-                        [999, 5.0, 999],
-                    ],
-                ),
-                "longitude": (
-                    ("y", "x"),
-                    [
-                        [999, 1.0, 999],
-                        [999, 2.0, 999],
-                        [999, 3.0, 999],
-                        [999, 4.0, 999],
-                        [999, 5.0, 999],
-                    ],
-                ),
-                "acq_time": ("y", np.arange(5).astype("datetime64[s]")),
-            }
-        )
-        ds["acq_time"].attrs["coords"] = "latitude longitude"
-        lons, times = collector._get_equator_crossings(ds)
-        np.testing.assert_equal(lons, [3, np.nan])
-        np.testing.assert_equal(
-            times, [np.datetime64("1970-01-01 00:00:02"), np.datetime64("NaT")]
-        )
-
-        # More than two equator crossings
-        ds = xr.Dataset(
-            coords={
-                "latitude": (
-                    ("y", "x"),
-                    [
-                        [999, -1, 999],
-                        [999, 1, 999],
-                        [999, -1, 999],
-                        [999, 1, 999],
-                        [999, -1, 999],
-                        [999, 1, 999],
-                    ],
-                ),
-                "longitude": (
-                    ("y", "x"),
-                    [
-                        [999, 1.0, 999],
-                        [999, 2.0, 999],
-                        [999, 3.0, 999],
-                        [999, 4.0, 999],
-                        [999, 5.0, 999],
-                        [999, 6.0, 999],
-                    ],
-                ),
-                "acq_time": ("y", np.arange(6).astype("datetime64[s]")),
-            }
-        )
-        ds["acq_time"].attrs["coords"] = "latitude longitude"
-        collector = MetadataCollector()
-        lons, times = collector._get_equator_crossings(ds)
-        np.testing.assert_equal(lons, [1, 3])
-        np.testing.assert_equal(
-            times,
-            [
-                np.datetime64("1970-01-01 00:00:00"),
-                np.datetime64("1970-01-01 00:00:02"),
-            ],
         )

--- a/pygac_fdr/tests/test_metadata.py
+++ b/pygac_fdr/tests/test_metadata.py
@@ -376,7 +376,7 @@ class TestMetadataEnhancer:
 
         # Check overlap computation (closed end)
         enhancer = MetadataEnhancer()
-        mda_overlap = enhancer._calc_overlap(mda.copy())
+        mda_overlap = enhancer._calc_overlap_single_platform(mda.copy())
         pd.testing.assert_series_equal(
             mda_overlap["overlap_free_start"],
             mda_overlap["overlap_free_start_exp"],
@@ -389,7 +389,9 @@ class TestMetadataEnhancer:
         )
 
         # Open end
-        mda_overlap_open_end = enhancer._calc_overlap(mda.copy(), open_end=True)
+        mda_overlap_open_end = enhancer._calc_overlap_single_platform(
+            mda.copy(), open_end=True
+        )
         np.testing.assert_equal(
             mda_overlap_open_end.iloc[-1]["overlap_free_end"], np.nan
         )


### PR DESCRIPTION
Grouping metadata by platform fails wIth more recent versions of pandas (>1.3.0). Fix that by not adding the platform as an index to the data frame.

Also includes a refactoring of the metadata collector. Split collection, enhancement and I/O into separate classes/methods.