### PR TITLE
Go back to Satpy<0.37

### DIFF
--- a/continuous_integration/environment.yaml
+++ b/continuous_integration/environment.yaml
@@ -10,7 +10,7 @@ dependencies:
   - xarray
   - netcdf4
   - h5py
-  - satpy
+  - satpy<0.37
   - pyyaml
   - pytest
   - pytest-cov

--- a/setup.py
+++ b/setup.py
@@ -39,7 +39,7 @@ if __name__ == "__main__":
         "netCDF4",
         "h5py",
         "pygac >=1.3.1",
-        "satpy >=0.25.0",
+        "satpy <0.37.0",
         "pyyaml",
         "trollsift",
         "fsspec",


### PR DESCRIPTION
Satpy-0.37+ requires Python-3.8 which breaks the current tests. Go back to Satpy<0.37 for the upcoming 0.2.1 release and then update to Python-3.8.