### PR TITLE
Update test matrix to Python 3.8 and 3.9

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -10,7 +10,7 @@ jobs:
       fail-fast: true
       matrix:
         os: ["ubuntu-latest"]
-        python-version: ["3.7", "3.8"]
+        python-version: ["3.8", "3.9"]
         experimental: [false]
 
     env:

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -24,7 +24,9 @@ jobs:
       - name: Setup Conda Environment
         uses: conda-incubator/setup-miniconda@v2
         with:
-          miniconda-version: "latest"
+          miniforge-variant: Mambaforge
+          miniforge-version: latest
+          use-mamba: true
           python-version: ${{ matrix.python-version }}
           environment-file: continuous_integration/environment.yaml
           activate-environment: test-environment

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -10,7 +10,7 @@ jobs:
       fail-fast: true
       matrix:
         os: ["ubuntu-latest"]
-        python-version: ["3.8", "3.9"]
+        python-version: ["3.8", "3.9", "3.10"]
         experimental: [false]
 
     env:

--- a/continuous_integration/environment.yaml
+++ b/continuous_integration/environment.yaml
@@ -10,7 +10,7 @@ dependencies:
   - xarray
   - netcdf4
   - h5py
-  - satpy<0.37
+  - satpy
   - pyyaml
   - pytest
   - pytest-cov

--- a/setup.py
+++ b/setup.py
@@ -77,5 +77,5 @@ if __name__ == "__main__":
         scripts=[os.path.join("bin", item) for item in os.listdir("bin")],
         install_requires=requires,
         extras_require=extras_require,
-        python_requires=">=3.6",
+        python_requires=">=3.8",
     )

--- a/setup.py
+++ b/setup.py
@@ -39,7 +39,7 @@ if __name__ == "__main__":
         "netCDF4",
         "h5py",
         "pygac >=1.3.1",
-        "satpy <0.37.0",
+        "satpy",
         "pyyaml",
         "trollsift",
         "fsspec",


### PR DESCRIPTION
That means we can test with the latest version of Satpy. Also, use mamba to speed up build times (from 4 to 3 minutes). 

Closes #106 .