### PR TITLE
Drop Python-3.8 support

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -10,7 +10,7 @@ jobs:
       fail-fast: true
       matrix:
         os: ["ubuntu-latest"]
-        python-version: ["3.8", "3.9", "3.10"]
+        python-version: ["3.9", "3.10", "3.11"]
         experimental: [false]
 
     env:

--- a/.github/workflows/end-to-end.yaml
+++ b/.github/workflows/end-to-end.yaml
@@ -16,7 +16,7 @@ jobs:
       fail-fast: true
       matrix:
         os: ["ubuntu-latest"]
-        python-version: ["3.10"]
+        python-version: ["3.12"]
         experimental: [false]
 
     env:

--- a/.github/workflows/end-to-end.yaml
+++ b/.github/workflows/end-to-end.yaml
@@ -16,7 +16,7 @@ jobs:
       fail-fast: true
       matrix:
         os: ["ubuntu-latest"]
-        python-version: ["3.8"]
+        python-version: ["3.10"]
         experimental: [false]
 
     env:

--- a/setup.py
+++ b/setup.py
@@ -77,5 +77,5 @@ if __name__ == "__main__":
         scripts=[os.path.join("bin", item) for item in os.listdir("bin")],
         install_requires=requires,
         extras_require=extras_require,
-        python_requires=">=3.8",
+        python_requires=">=3.9",
     )


### PR DESCRIPTION
Drop Python-3.8 support since Satpy requires Python >= 3.9