### PR TITLE
Drop Python-3.9 support

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -10,7 +10,7 @@ jobs:
       fail-fast: true
       matrix:
         os: ["ubuntu-latest"]
-        python-version: ["3.9", "3.10", "3.11"]
+        python-version: ["3.10", "3.11", "3.12"]
         experimental: [false]
 
     env:

--- a/setup.py
+++ b/setup.py
@@ -77,5 +77,5 @@ if __name__ == "__main__":
         scripts=[os.path.join("bin", item) for item in os.listdir("bin")],
         install_requires=requires,
         extras_require=extras_require,
-        python_requires=">=3.9",
+        python_requires=">=3.10",
     )


### PR DESCRIPTION
Pyspectral now requires Python >= 3.10