### PR TITLE
Fix netCDF encoding in tests

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -24,13 +24,10 @@ jobs:
       - name: Setup Conda Environment
         uses: conda-incubator/setup-miniconda@v3
         with:
-          miniforge-variant: Mambaforge
           miniforge-version: latest
-          use-mamba: true
           python-version: ${{ matrix.python-version }}
-          environment-file: continuous_integration/environment.yaml
           activate-environment: test-environment
-
+          channels: conda-forge
       - name: Install pygac-fdr
         shell: bash -l {0}
         run: |

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -26,8 +26,8 @@ jobs:
         with:
           miniforge-version: latest
           python-version: ${{ matrix.python-version }}
+          environment-file: continuous_integration/environment.yaml
           activate-environment: test-environment
-          channels: conda-forge
       - name: Install pygac-fdr
         shell: bash -l {0}
         run: |

--- a/pygac_fdr/tests/test_writer.py
+++ b/pygac_fdr/tests/test_writer.py
@@ -52,18 +52,17 @@ class NetcdfWriterTest(unittest.TestCase):
         }
         for ch, data in test_data.items():
             enc = DEFAULT_ENCODING[ch]
-            data_enc = ((data - enc["add_offset"]) / enc["scale_factor"]).astype(
-                enc["dtype"]
-            )
-            data_dec = data_enc * enc["scale_factor"] + enc["add_offset"]
+            offset = enc.get("add_offset", 0.0)
+            data_enc = ((data - offset) / enc["scale_factor"]).astype(enc["dtype"])
+            data_dec = data_enc * enc["scale_factor"] + offset
             np.testing.assert_allclose(data_dec, data, rtol=0.1)
 
 
 class TestNetcdfWriter:
     @pytest.fixture
     def scene_lonlats(self):
-        lons = [[5, 6], [7, 8]]
-        lats = [[1, 2], [3, 4]]
+        lons = [[5.0, 6.0], [7.0, 8.0]]
+        lats = [[1.0, 2.0], [3.0, 4.0]]
         return lons, lats
 
     @pytest.fixture(params=[True, False])
@@ -107,7 +106,7 @@ class TestNetcdfWriter:
         lat_id = make_dataid(name="latitude", resolution=1234.0, modifiers=())
         qual_flags_id = make_dataid(name="qual_flags", resolution=1234.0, modifiers=())
         scene[ch4_id] = xr.DataArray(
-            [[1, 2], [3, 4]],
+            [[1.0, 2.0], [3.0, 4.0]],
             dims=("y", "x"),
             coords={
                 "acq_time": ("y", acq_time),

--- a/pygac_fdr/writer.py
+++ b/pygac_fdr/writer.py
@@ -60,7 +60,6 @@ DEFAULT_ENCODING = {
     "reflectance_channel_1": {
         "dtype": "int16",
         "scale_factor": 0.01,
-        "add_offset": 0,
         "_FillValue": FILL_VALUE_INT16,
         "zlib": True,
         "complevel": 4,
@@ -68,7 +67,6 @@ DEFAULT_ENCODING = {
     "reflectance_channel_2": {
         "dtype": "int16",
         "scale_factor": 0.01,
-        "add_offset": 0,
         "_FillValue": FILL_VALUE_INT16,
         "zlib": True,
         "complevel": 4,
@@ -84,7 +82,6 @@ DEFAULT_ENCODING = {
     "reflectance_channel_3a": {
         "dtype": "int16",
         "scale_factor": 0.01,
-        "add_offset": 0,
         "_FillValue": FILL_VALUE_INT16,
         "zlib": True,
         "complevel": 4,
@@ -116,7 +113,6 @@ DEFAULT_ENCODING = {
     "latitude": {
         "dtype": "int32",
         "scale_factor": 0.001,
-        "add_offset": 0,
         "_FillValue": FILL_VALUE_INT32,
         "zlib": True,
         "complevel": 4,
@@ -124,7 +120,6 @@ DEFAULT_ENCODING = {
     "longitude": {
         "dtype": "int32",
         "scale_factor": 0.001,
-        "add_offset": 0,
         "_FillValue": FILL_VALUE_INT32,
         "zlib": True,
         "complevel": 4,
@@ -132,7 +127,6 @@ DEFAULT_ENCODING = {
     "sensor_azimuth_angle": {
         "dtype": "int16",
         "scale_factor": 0.01,
-        "add_offset": 0.0,
         "_FillValue": FILL_VALUE_INT16,
         "zlib": True,
         "complevel": 4,
@@ -140,7 +134,6 @@ DEFAULT_ENCODING = {
     "sensor_zenith_angle": {
         "dtype": "int16",
         "scale_factor": 0.01,
-        "add_offset": 0,
         "_FillValue": FILL_VALUE_INT16,
         "zlib": True,
         "complevel": 4,
@@ -148,7 +141,6 @@ DEFAULT_ENCODING = {
     "solar_azimuth_angle": {
         "dtype": "int16",
         "scale_factor": 0.01,
-        "add_offset": 0.0,
         "_FillValue": FILL_VALUE_INT16,
         "zlib": True,
         "complevel": 4,
@@ -156,7 +148,6 @@ DEFAULT_ENCODING = {
     "solar_zenith_angle": {
         "dtype": "int16",
         "scale_factor": 0.01,
-        "add_offset": 0,
         "_FillValue": FILL_VALUE_INT16,
         "zlib": True,
         "complevel": 4,
@@ -164,7 +155,6 @@ DEFAULT_ENCODING = {
     "sun_sensor_azimuth_difference_angle": {
         "dtype": "int16",
         "scale_factor": 0.01,
-        "add_offset": 0,
         "_FillValue": FILL_VALUE_INT16,
         "zlib": True,
         "complevel": 4,


### PR DESCRIPTION
There was a type mismatch between test data (int) and add_offset (float). I also removed all zero offsets to simplify encoding. CI pipeline now uses miniforge.