### PR TITLE
Adapt metadata computation to most recent pandas version

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -10,7 +10,7 @@ jobs:
       fail-fast: true
       matrix:
         os: ["ubuntu-latest"]
-        python-version: ["3.10", "3.11", "3.12"]
+        python-version: ["3.11", "3.12", "3.13"]
         experimental: [false]
 
     env:
@@ -22,7 +22,7 @@ jobs:
         uses: actions/checkout@v6
 
       - name: Setup Conda Environment
-        uses: conda-incubator/setup-miniconda@v3
+        uses: conda-incubator/setup-miniconda@v4
         with:
           miniforge-version: latest
           python-version: ${{ matrix.python-version }}

--- a/.github/workflows/end-to-end.yaml
+++ b/.github/workflows/end-to-end.yaml
@@ -28,7 +28,7 @@ jobs:
         uses: actions/checkout@v6
 
       - name: Setup Conda Environment
-        uses: conda-incubator/setup-miniconda@v3
+        uses: conda-incubator/setup-miniconda@v4
         with:
           miniconda-version: "latest"
           python-version: ${{ matrix.python-version }}

--- a/pygac_fdr/metadata.py
+++ b/pygac_fdr/metadata.py
@@ -227,14 +227,13 @@ class MetadataEnhancer:
 
     def _set_global_quality_flag(self, df):
         LOG.info("Computing quality flags")
-        grouped = df.groupby("platform", as_index=False, group_keys=False)
+        grouped = df.groupby("platform")
         return grouped.apply(
             lambda x: self._set_global_qual_flags_single_platform(x, x.name)
         )
 
     def _set_global_qual_flags_single_platform(self, df, platform):
         """Set global quality flags."""
-        df = df.reset_index(drop=True)
         self._set_invalid_timestamp_flag(df, platform)
         self._set_too_short_flag(df)
         self._set_too_long_flag(df)
@@ -303,9 +302,7 @@ class MetadataEnhancer:
         Two files are considered equal if platform, start- and end-time are identical. This happens
         if the same measurement has been transferred to two different ground stations.
         """
-        gs_dupl = df.duplicated(
-            subset=["platform", "start_time", "end_time"], keep="first"
-        )
+        gs_dupl = df.duplicated(subset=["start_time", "end_time"], keep="first")
         df.loc[gs_dupl, "global_quality_flag"] = QualityFlags.DUPLICATE
 
     def _set_invalid_timestamp_flag(self, df, platform):
@@ -378,7 +375,9 @@ class MetadataEnhancer:
             if prev_row is not None:
                 if prev_row["end_time"] >= this_row["start_time"]:
                     prev_end_time = prev_row["end_time"].to_datetime64()
-                    overlap_free_start = (this_time > prev_end_time).argmax().values
+                    overlap_free_start = (
+                        (this_time > prev_end_time).argmax(axis=0).values
+                    )
                 else:
                     overlap_free_start = 0
                 df.loc[df_ok.index[i], "overlap_free_start"] = overlap_free_start
@@ -390,9 +389,9 @@ class MetadataEnhancer:
             if next_row is not None:
                 if this_row["end_time"] >= next_row["start_time"]:
                     next_start_time = next_row["start_time"].to_datetime64()
-                    overlap_free_end = (
-                        this_time >= next_start_time
-                    ).argmax().values - 1
+                    overlap_free_end = (this_time >= next_start_time).argmax(
+                        axis=0
+                    ).values - 1
                 else:
                     overlap_free_end = this_row["along_track"] - 1
                 df.loc[df_ok.index[i], "overlap_free_end"] = overlap_free_end

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,7 +8,7 @@ dynamic = ["version"]
 description = "Python package for creating a Fundamental Data Record (FDR) of AVHRR GAC data using pygac"
 readme = "README.md"
 license = { file = "LICENSE" }
-requires-python = ">=3.10"
+requires-python = ">=3.11"
 authors = [
     { name = "The Pytroll Team", email = "pytroll@googlegroups.com" },
 ]


### PR DESCRIPTION
Fix error when grouping a data frame by platform and a deprecation warning related to `argmax`. Also, drop Python-3.10 support.